### PR TITLE
Fix draft tracker cold start with localStorage persistence

### DIFF
--- a/web/src/app/api/draft/route.ts
+++ b/web/src/app/api/draft/route.ts
@@ -1,35 +1,17 @@
-import { loadDraftSession, saveDraftSession } from "@/lib/draft-store";
+import type { DraftSession } from "@/lib/draft-context";
+
+const EMPTY: DraftSession = { drafted: [], myPicks: [], myRoster: {} };
 
 export async function GET() {
-  return Response.json(loadDraftSession());
+  return Response.json(EMPTY);
 }
 
 export async function POST(req: Request) {
   const body = await req.json();
-  const session = loadDraftSession();
 
-  if (body.action === "draft") {
-    const name = body.player as string;
-    if (!session.drafted.includes(name)) {
-      session.drafted.push(name);
-      if (body.isMine) session.myPicks.push(name);
-    }
-  } else if (body.action === "undo") {
-    const last = session.drafted.pop();
-    if (last) {
-      const idx = session.myPicks.indexOf(last);
-      if (idx !== -1) session.myPicks.splice(idx, 1);
-    }
-  } else if (body.action === "reset") {
-    session.drafted = [];
-    session.myPicks = [];
-    session.myRoster = {};
-  } else if (body.action === "assign") {
-    session.myRoster[body.slot] = body.player;
-  } else if (body.action === "unassign") {
-    delete session.myRoster[body.slot];
+  if (body.action === "reset") {
+    return Response.json(EMPTY);
   }
 
-  saveDraftSession(session);
-  return Response.json(session);
+  return Response.json(body.session ?? EMPTY);
 }

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { ConditionalNav } from "@/components/ConditionalNav";
+import { Providers } from "./providers";
 
 const sans = Inter({ variable: "--font-sans", subsets: ["latin"] });
 const mono = JetBrains_Mono({ variable: "--font-mono", subsets: ["latin"] });
@@ -18,7 +19,9 @@ export default function RootLayout({
     <html lang="en" className={`${sans.variable} ${mono.variable} h-full`}>
       <body className="flex min-h-full flex-col bg-background font-[family-name:var(--font-sans)] text-foreground antialiased">
         <ConditionalNav />
-        <main className="flex-1">{children}</main>
+        <Providers>
+          <main className="flex-1">{children}</main>
+        </Providers>
       </body>
     </html>
   );

--- a/web/src/app/providers.tsx
+++ b/web/src/app/providers.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { DraftProvider } from "@/lib/draft-context";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <DraftProvider>{children}</DraftProvider>;
+}

--- a/web/src/app/scarcity/page.tsx
+++ b/web/src/app/scarcity/page.tsx
@@ -3,12 +3,7 @@
 import { useState, useEffect, useMemo } from "react";
 import type { Player } from "@/lib/data";
 import type { EspnPlayerData } from "@/app/api/espn-adp/route";
-
-interface DraftSession {
-  drafted: string[];
-  myPicks: string[];
-  myRoster: Record<string, string>;
-}
+import { useDraft } from "@/lib/draft-context";
 
 const POSITIONS = ["C", "1B", "2B", "3B", "SS", "OF", "SP", "RP"] as const;
 
@@ -33,13 +28,12 @@ function urgencyTag(pct: number): { label: string; color: string; bar: string } 
 
 export default function ScarcityPage() {
   const [players, setPlayers] = useState<Player[]>([]);
-  const [session, setSession] = useState<DraftSession>({ drafted: [], myPicks: [], myRoster: {} });
+  const { session } = useDraft();
   const [espnData, setEspnData] = useState<Record<string, EspnPlayerData>>({});
   const [drillPos, setDrillPos] = useState<string>("");
 
   useEffect(() => {
     fetch("/api/rankings").then((r) => r.json()).then(setPlayers);
-    fetch("/api/draft").then((r) => r.json()).then(setSession);
     fetch("/api/espn-adp").then((r) => r.json()).then((data) => {
       if (!data.error) setEspnData(data);
     });

--- a/web/src/app/team/page.tsx
+++ b/web/src/app/team/page.tsx
@@ -2,12 +2,7 @@
 
 import { useState, useEffect, useMemo, useCallback } from "react";
 import type { Player } from "@/lib/data";
-
-interface DraftSession {
-  drafted: string[];
-  myPicks: string[];
-  myRoster: Record<string, string>;
-}
+import { useDraft } from "@/lib/draft-context";
 
 const ROSTER_SLOTS = [
   "C", "1B", "2B", "3B", "SS", "OF1", "OF2", "OF3", "UTIL",
@@ -44,14 +39,11 @@ const PIT_STATS = ["K", "QS", "W", "L", "SV", "HD", "ERA", "WHIP"] as const;
 
 export default function TeamPage() {
   const [players, setPlayers] = useState<Player[]>([]);
-  const [session, setSession] = useState<DraftSession>({
-    drafted: [], myPicks: [], myRoster: {},
-  });
+  const { session, assignSlot: ctxAssign, unassignSlot: ctxUnassign } = useDraft();
   const [assigningSlot, setAssigningSlot] = useState<Slot | null>(null);
 
   useEffect(() => {
     fetch("/api/rankings").then((r) => r.json()).then(setPlayers);
-    fetch("/api/draft").then((r) => r.json()).then(setSession);
   }, []);
 
   const playerMap = useMemo(() => {
@@ -75,24 +67,14 @@ export default function TeamPage() {
     [myPickPlayers, assignedNames]
   );
 
-  const assignPlayer = useCallback(async (slot: Slot, playerName: string) => {
-    const res = await fetch("/api/draft", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action: "assign", slot, player: playerName }),
-    });
-    setSession(await res.json());
+  const assignPlayer = useCallback((slot: Slot, playerName: string) => {
+    ctxAssign(slot, playerName);
     setAssigningSlot(null);
-  }, []);
+  }, [ctxAssign]);
 
-  const unassignSlot = useCallback(async (slot: Slot) => {
-    const res = await fetch("/api/draft", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action: "unassign", slot }),
-    });
-    setSession(await res.json());
-  }, []);
+  const unassignSlot = useCallback((slot: Slot) => {
+    ctxUnassign(slot);
+  }, [ctxUnassign]);
 
   const rosteredPlayers = useMemo(() => {
     const list: Player[] = [];

--- a/web/src/app/warroom/page.tsx
+++ b/web/src/app/warroom/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import type { Player, StandingsRow } from "@/lib/data";
+import { useDraft } from "@/lib/draft-context";
 
 // ── Draft order ───────────────────────────────────────────────────────────────
 
@@ -48,14 +49,6 @@ const STARTER_COUNTS: Record<string, number> = {
   OF: 30, SP: 50, RP: 20,
 };
 
-// ── Types ─────────────────────────────────────────────────────────────────────
-
-interface DraftSession {
-  drafted: string[];
-  myPicks: string[];
-  myRoster: Record<string, string>;
-}
-
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function zColor(z: number): string {
@@ -88,7 +81,7 @@ function urgencyTag(pct: number): { label: string; color: string; bar: string } 
 
 export default function DraftBoardPage() {
   const [players, setPlayers] = useState<Player[]>([]);
-  const [session, setSession] = useState<DraftSession>({ drafted: [], myPicks: [], myRoster: {} });
+  const { session, draftPlayer: ctxDraft, undoLast: ctxUndo, resetDraft: ctxReset } = useDraft();
   const [typeFilter, setTypeFilter] = useState<"All" | "BAT" | "PIT">("All");
   const [posFilter, setPosFilter] = useState<string[]>([]);
   const [search, setSearch] = useState("");
@@ -106,7 +99,6 @@ export default function DraftBoardPage() {
 
   useEffect(() => {
     fetch("/api/rankings").then((r) => r.json()).then(setPlayers);
-    fetch("/api/draft").then((r) => r.json()).then(setSession);
     fetch("/api/espn-adp").then((r) => r.json()).then((data) => {
       if (!data.error) setEspnData(data);
     });
@@ -309,37 +301,21 @@ export default function DraftBoardPage() {
 
   // ── Actions ────────────────────────────────────────────────────────────────
 
-  const draftPlayer = useCallback(async (name: string, mine: boolean) => {
-    const res = await fetch("/api/draft", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action: "draft", player: name, isMine: mine }),
-    });
-    setSession(await res.json());
-    // Auto-advance: clear manual selection so next pick follows draft order
+  const draftPlayer = useCallback((name: string, mine: boolean) => {
+    ctxDraft(name, mine);
     setSelectedDrafter(null);
-  }, []);
+  }, [ctxDraft]);
 
-  const undoLast = useCallback(async () => {
-    const res = await fetch("/api/draft", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action: "undo" }),
-    });
-    setSession(await res.json());
+  const undoLast = useCallback(() => {
+    ctxUndo();
     setSelectedDrafter(null);
-  }, []);
+  }, [ctxUndo]);
 
-  const resetDraft = useCallback(async () => {
+  const resetDraft = useCallback(() => {
     if (!confirm("Reset entire draft?")) return;
-    const res = await fetch("/api/draft", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action: "reset" }),
-    });
-    setSession(await res.json());
+    ctxReset();
     setSelectedDrafter(null);
-  }, []);
+  }, [ctxReset]);
 
   const togglePos = (pos: string) =>
     setPosFilter((prev) =>

--- a/web/src/lib/draft-context.tsx
+++ b/web/src/lib/draft-context.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { createContext, useContext, useReducer, useEffect, useRef, type ReactNode } from "react";
+
+export interface DraftSession {
+  drafted: string[];
+  myPicks: string[];
+  myRoster: Record<string, string>;
+}
+
+const STORAGE_KEY = "draft-session";
+
+const DEFAULT_SESSION: DraftSession = { drafted: [], myPicks: [], myRoster: {} };
+
+type DraftAction =
+  | { type: "draft"; player: string; isMine: boolean }
+  | { type: "undo" }
+  | { type: "reset" }
+  | { type: "assign"; slot: string; player: string }
+  | { type: "unassign"; slot: string }
+  | { type: "hydrate"; session: DraftSession };
+
+function draftReducer(state: DraftSession, action: DraftAction): DraftSession {
+  switch (action.type) {
+    case "draft": {
+      if (state.drafted.includes(action.player)) return state;
+      return {
+        ...state,
+        drafted: [...state.drafted, action.player],
+        myPicks: action.isMine ? [...state.myPicks, action.player] : state.myPicks,
+      };
+    }
+    case "undo": {
+      const last = state.drafted[state.drafted.length - 1];
+      if (!last) return state;
+      return {
+        ...state,
+        drafted: state.drafted.slice(0, -1),
+        myPicks: state.myPicks.filter((n) => n !== last),
+      };
+    }
+    case "reset":
+      return { drafted: [], myPicks: [], myRoster: {} };
+    case "assign":
+      return { ...state, myRoster: { ...state.myRoster, [action.slot]: action.player } };
+    case "unassign": {
+      const next = { ...state.myRoster };
+      delete next[action.slot];
+      return { ...state, myRoster: next };
+    }
+    case "hydrate":
+      return action.session;
+    default:
+      return state;
+  }
+}
+
+interface DraftContextValue {
+  session: DraftSession;
+  draftPlayer: (player: string, isMine: boolean) => void;
+  undoLast: () => void;
+  resetDraft: () => void;
+  assignSlot: (slot: string, player: string) => void;
+  unassignSlot: (slot: string) => void;
+}
+
+const DraftContext = createContext<DraftContextValue | null>(null);
+
+export function DraftProvider({ children }: { children: ReactNode }) {
+  const [session, dispatch] = useReducer(draftReducer, DEFAULT_SESSION);
+  const hydrated = useRef(false);
+
+  useEffect(() => {
+    if (!hydrated.current) {
+      hydrated.current = true;
+      if (typeof window === "undefined") return;
+      try {
+        const saved = localStorage.getItem(STORAGE_KEY);
+        if (saved) {
+          const parsed = JSON.parse(saved) as DraftSession;
+          if (parsed && Array.isArray(parsed.drafted)) {
+            dispatch({ type: "hydrate", session: parsed });
+          }
+        }
+      } catch {
+        // corrupted data, start fresh
+      }
+      return;
+    }
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+    } catch {
+      // storage full or unavailable
+    }
+  }, [session]);
+
+  const value: DraftContextValue = {
+    session,
+    draftPlayer: (player, isMine) => dispatch({ type: "draft", player, isMine }),
+    undoLast: () => dispatch({ type: "undo" }),
+    resetDraft: () => dispatch({ type: "reset" }),
+    assignSlot: (slot, player) => dispatch({ type: "assign", slot, player }),
+    unassignSlot: (slot) => dispatch({ type: "unassign", slot }),
+  };
+
+  return <DraftContext value={value}>{children}</DraftContext>;
+}
+
+export function useDraft(): DraftContextValue {
+  const ctx = useContext(DraftContext);
+  if (!ctx) throw new Error("useDraft must be used within a DraftProvider");
+  return ctx;
+}


### PR DESCRIPTION
Closes #4

## Summary
- Replaced in-memory `draft-store.ts` module-level state with client-side React context + `useReducer` backed by `localStorage`
- Draft state now survives page reloads and serverless cold starts
- SSR-safe hydration: renders default empty state on server, hydrates from localStorage on mount via `useEffect`
- API route made stateless (returns empty defaults); all state management moved to the client
- Three consuming pages (warroom, scarcity, team) updated to use `useDraft()` hook instead of fetch calls

## Changes
| File | Change |
|---|---|
| `web/src/lib/draft-context.tsx` | New: DraftProvider context with useReducer + localStorage persistence |
| `web/src/app/providers.tsx` | New: Client component wrapper for root layout |
| `web/src/app/layout.tsx` | Wrap children with Providers |
| `web/src/app/api/draft/route.ts` | Made stateless, returns empty defaults |
| `web/src/app/warroom/page.tsx` | Use useDraft() hook, remove fetch calls |
| `web/src/app/scarcity/page.tsx` | Use useDraft() hook, remove fetch call |
| `web/src/app/team/page.tsx` | Use useDraft() hook, remove fetch calls |

## Test plan
- [ ] Draft a player, reload the page: state should persist
- [ ] Navigate between warroom/scarcity/team: draft state should be shared
- [ ] Reset draft, reload: state should be cleared
- [ ] Open in incognito (no localStorage data): should start with empty state, no hydration errors
- [ ] TypeScript strict mode: passes (`npx tsc --noEmit`)
- [ ] Next.js build: passes (`npx next build`)
- [ ] No new lint errors introduced (verified against baseline)