### PR TITLE
Add pino structured logging with per-request tracing

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  serverExternalPackages: ["pino", "pino-pretty"],
 };
 
 export default nextConfig;

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "lucide-react": "^0.577.0",
         "next": "16.2.1",
+        "pino": "^10.3.1",
+        "pino-pretty": "^13.1.3",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "recharts": "^3.8.0"
@@ -1624,6 +1626,12 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
@@ -3497,6 +3505,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -3787,6 +3804,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4047,6 +4070,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4189,6 +4221,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -4891,6 +4932,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4940,6 +4987,12 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
     "node_modules/fast-string-truncated-width": {
@@ -5399,6 +5452,12 @@
         "@types/set-cookie-parser": "^2.4.10",
         "set-cookie-parser": "^3.0.1"
       }
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
@@ -6028,6 +6087,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6641,7 +6709,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6991,6 +7058,24 @@
       ],
       "license": "MIT"
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7152,6 +7237,79 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -7236,6 +7394,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7246,6 +7420,16 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -7277,6 +7461,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
     "node_modules/react": {
@@ -7327,6 +7517,15 @@
         "redux": {
           "optional": true
         }
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/recharts": {
@@ -7623,6 +7822,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -7641,6 +7849,22 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -7885,6 +8109,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7892,6 +8125,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stable-hash": {
@@ -8205,6 +8447,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tiny-invariant": {
@@ -9117,6 +9371,12 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "lucide-react": "^0.577.0",
     "next": "16.2.1",
+    "pino": "^10.3.1",
+    "pino-pretty": "^13.1.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "recharts": "^3.8.0"

--- a/web/src/app/api/analysis/advisor/route.ts
+++ b/web/src/app/api/analysis/advisor/route.ts
@@ -1,4 +1,5 @@
 import { espnFetch, hasEspnCreds, STAT_ID_MAP, POS_MAP, getProTeam, getCurrentMatchupPeriod, getMatchupDates } from "@/lib/espn";
+import logger from "@/lib/logger";
 
 interface Recommendation {
   type: "score" | "target" | "alert" | "stream" | "sit";
@@ -11,12 +12,15 @@ const MY_TEAM_ID = parseInt(process.env.MY_ESPN_TEAM_ID ?? "0");
 const CATS_ORDER = ["H", "R", "HR", "TB", "RBI", "BB", "SB", "AVG", "K", "QS", "W", "L", "SV", "HD", "ERA", "WHIP"];
 const LOWER_IS_BETTER = new Set(["ERA", "WHIP", "L"]);
 
-export async function GET() {
+export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
   if (!hasEspnCreds() || !MY_TEAM_ID) {
     return Response.json({ recommendations: [] });
   }
 
   try {
+    const t0 = Date.now();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const data: any = await espnFetch(["mMatchup", "mMatchupScore", "mRoster", "mTeam", "mStatus", "mSettings"]);
     const currentPeriod = getCurrentMatchupPeriod(data);
@@ -174,8 +178,10 @@ export async function GET() {
       }
     }
 
+    log.info({ op: "advisor", count: recommendations.length, durationMs: Date.now() - t0 }, "ok");
     return Response.json({ recommendations });
   } catch (err) {
+    log.error({ op: "advisor", err: String(err) }, "failed");
     return Response.json({ recommendations: [{ type: "alert", title: "Error", description: String(err), priority: "low" }] });
   }
 }

--- a/web/src/app/api/analysis/gm-advice/route.ts
+++ b/web/src/app/api/analysis/gm-advice/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = "force-dynamic";
 export const maxDuration = 30;
+import logger from "@/lib/logger";
 
 const CATS_ORDER = ["H", "R", "HR", "TB", "RBI", "BB", "SB", "AVG", "K", "QS", "W", "L", "SV", "HD", "ERA", "WHIP"];
 const LOWER_IS_BETTER = new Set(["ERA", "WHIP", "L"]);
@@ -181,6 +182,9 @@ function buildPrompt(matchup: any, league: any, standings: any, schedule: any, z
 }
 
 export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
+  const t0 = Date.now();
   const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY;
   if (!ANTHROPIC_KEY) {
     return Response.json({ error: "ANTHROPIC_API_KEY_MISSING" }, { status: 503 });
@@ -247,5 +251,6 @@ Every bullet starts with an action verb. Name players. Quote their stats. Be blu
     return Response.json({ error: "Failed to parse AI response", raw: rawText }, { status: 500 });
   }
 
+  log.info({ op: "gm-advice", durationMs: Date.now() - t0 }, "ok");
   return Response.json({ ...advice, generatedAt: new Date().toISOString() });
 }

--- a/web/src/app/api/analysis/z-scores/route.ts
+++ b/web/src/app/api/analysis/z-scores/route.ts
@@ -1,5 +1,6 @@
 import { hasEspnCreds, getProTeam } from "@/lib/espn";
 import { mean, stddev } from "@/lib/z-scores";
+import logger from "@/lib/logger";
 
 const LEAGUE_ID = 4739;
 const SEASON = 2026;
@@ -45,7 +46,9 @@ export interface ZScorePlayer {
   far: number;
 }
 
-export async function GET() {
+export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
   if (!hasEspnCreds()) {
     return Response.json({ error: "ESPN_CREDS_MISSING" }, { status: 401 });
   }
@@ -54,6 +57,7 @@ export async function GET() {
   const swid = process.env.ESPN_SWID!;
 
   try {
+    const t0 = Date.now();
     // Fetch all players (rostered + free agents) and category weights in parallel
     const filters = {
       players: {
@@ -220,6 +224,7 @@ export async function GET() {
     // Combine and sort by FAR descending
     const allPlayers = [...batterResults, ...pitcherResults].sort((a, b) => b.far - a.far);
 
+    log.info({ op: "z-scores", count: allPlayers.length, durationMs: Date.now() - t0 }, "ok");
     return Response.json({
       players: allPlayers,
       count: allPlayers.length,
@@ -229,6 +234,7 @@ export async function GET() {
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    log.error({ op: "z-scores", err: msg }, "failed");
     return Response.json({ error: msg }, { status: 502 });
   }
 }

--- a/web/src/app/api/draft-results/route.ts
+++ b/web/src/app/api/draft-results/route.ts
@@ -1,5 +1,11 @@
 import { getDraftResults } from "@/lib/data";
+import logger from "@/lib/logger";
 
-export async function GET() {
-  return Response.json(await getDraftResults());
+export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
+  const t0 = Date.now();
+  const data = await getDraftResults();
+  log.info({ op: "draft-results", durationMs: Date.now() - t0 }, "ok");
+  return Response.json(data);
 }

--- a/web/src/app/api/draft/route.ts
+++ b/web/src/app/api/draft/route.ts
@@ -1,17 +1,25 @@
 import type { DraftSession } from "@/lib/draft-context";
+import logger from "@/lib/logger";
 
 const EMPTY: DraftSession = { drafted: [], myPicks: [], myRoster: {} };
 
-export async function GET() {
+export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
+  log.info({ op: "draft-get" }, "ok");
   return Response.json(EMPTY);
 }
 
 export async function POST(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
   const body = await req.json();
 
   if (body.action === "reset") {
+    log.info({ op: "draft-reset" }, "ok");
     return Response.json(EMPTY);
   }
 
+  log.info({ op: "draft-update" }, "ok");
   return Response.json(body.session ?? EMPTY);
 }

--- a/web/src/app/api/espn-adp/route.ts
+++ b/web/src/app/api/espn-adp/route.ts
@@ -54,8 +54,13 @@ export interface EspnPlayerData {
   espnRank: number | null;
 }
 
-export async function GET() {
+import logger from "@/lib/logger";
+
+export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
   try {
+    const t0 = Date.now();
     const res = await fetch(
       "https://lm-api-reads.fantasy.espn.com/apis/v3/games/flb/seasons/2026/segments/0/leaguedefaults/3?view=kona_player_info&scoringPeriodId=0",
       {
@@ -109,8 +114,10 @@ export async function GET() {
       };
     }
 
+    log.info({ op: "espn-adp", durationMs: Date.now() - t0 }, "ok");
     return Response.json(result);
   } catch (err) {
+    log.error({ op: "espn-adp", err: String(err) }, "failed");
     return Response.json({ error: String(err) }, { status: 502 });
   }
 }

--- a/web/src/app/api/espn/h2h/route.ts
+++ b/web/src/app/api/espn/h2h/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = "force-dynamic";
 import { espnFetch, hasEspnCreds, STAT_ID_MAP } from "@/lib/espn";
+import logger from "@/lib/logger";
 
 export interface H2HMatchup {
   week: number;
@@ -45,7 +46,9 @@ const LOWER_IS_BETTER = new Set(["ERA", "WHIP", "L"]);
 const MY_TEAM_ID = parseInt(process.env.MY_ESPN_TEAM_ID ?? "0");
 const CATS_ORDER = ["H", "R", "HR", "TB", "RBI", "BB", "SB", "AVG", "K", "QS", "W", "L", "SV", "HD", "ERA", "WHIP"];
 
-export async function GET() {
+export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
   if (!hasEspnCreds()) {
     return Response.json({ error: "ESPN_CREDS_MISSING" }, { status: 401 });
   }
@@ -54,6 +57,7 @@ export async function GET() {
   }
 
   try {
+    const t0 = Date.now();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const data: any = await espnFetch(["mMatchup", "mMatchupScore", "mTeam", "mStatus"]);
 
@@ -226,9 +230,11 @@ export async function GET() {
       },
     };
 
+    log.info({ op: "h2h", durationMs: Date.now() - t0 }, "ok");
     return Response.json(result);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    log.error({ op: "h2h", err: msg }, "failed");
     return Response.json({ error: msg }, { status: 502 });
   }
 }

--- a/web/src/app/api/espn/league-stats/route.ts
+++ b/web/src/app/api/espn/league-stats/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = "force-dynamic";
 import { espnFetch, hasEspnCreds, STAT_ID_MAP } from "@/lib/espn";
+import logger from "@/lib/logger";
 
 export interface TeamCategoryStats {
   teamId: number;
@@ -200,6 +201,8 @@ function rankTeams(
 }
 
 export async function GET(request: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(request.url).pathname });
   const { searchParams } = new URL(request.url);
   const scope = (searchParams.get("scope") ?? "week") as "week" | "season";
 
@@ -211,6 +214,7 @@ export async function GET(request: Request) {
   }
 
   try {
+    const t0 = Date.now();
     const data: any = await espnFetch(["mMatchup", "mMatchupScore", "mTeam", "mStatus"]); // eslint-disable-line @typescript-eslint/no-explicit-any
     const currentMatchupPeriod = data.status?.currentMatchupPeriod ?? 1;
     const schedule: any[] = data.schedule ?? []; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -276,9 +280,11 @@ export async function GET(request: Request) {
 
     teams.sort((a, b) => b.wins - a.wins || a.losses - b.losses);
 
+    log.info({ op: "league-stats", scope, durationMs: Date.now() - t0 }, "ok");
     return Response.json({ scope, scoringPeriodId: currentMatchupPeriod, myTeamId: MY_TEAM_ID, teams, averages } as LeagueStatsData);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    log.error({ op: "league-stats", err: msg }, "failed");
     return Response.json({ error: msg }, { status: 502 });
   }
 }

--- a/web/src/app/api/espn/matchup/route.ts
+++ b/web/src/app/api/espn/matchup/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = "force-dynamic";
 import { espnFetch, hasEspnCreds, POS_MAP, SLOT_MAP, INJURY_MAP, STAT_ID_MAP, getProTeam, getMatchupDates, getCurrentMatchupPeriod } from "@/lib/espn";
+import logger from "@/lib/logger";
 
 export interface MatchupCatResult {
   cat: string;
@@ -195,7 +196,9 @@ function parseMatchup(data: any, myTeamId: number): MatchupData | null {
   };
 }
 
-export async function GET() {
+export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
   if (!hasEspnCreds()) {
     return Response.json({ error: "ESPN_CREDS_MISSING" }, { status: 401 });
   }
@@ -203,14 +206,17 @@ export async function GET() {
     return Response.json({ error: "MY_ESPN_TEAM_ID_MISSING" }, { status: 401 });
   }
   try {
+    const t0 = Date.now();
     const data = await espnFetch(["mMatchup", "mMatchupScore", "mRoster", "mTeam", "mSettings", "mStatus"]);
     const matchup = parseMatchup(data, MY_TEAM_ID);
     if (!matchup) {
       return Response.json({ error: "NO_MATCHUP_FOUND" }, { status: 404 });
     }
+    log.info({ op: "matchup", durationMs: Date.now() - t0 }, "ok");
     return Response.json(matchup);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    log.error({ op: "matchup", err: msg }, "failed");
     return Response.json({ error: msg }, { status: 502 });
   }
 }

--- a/web/src/app/api/espn/player-stats/route.ts
+++ b/web/src/app/api/espn/player-stats/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = "force-dynamic";
 import { hasEspnCreds, STAT_ID_MAP, getProTeam } from "@/lib/espn";
+import logger from "@/lib/logger";
 
 // Fetch current season stats for all rostered players
 // Uses ESPN's kona_player_info view with season stats
@@ -34,6 +35,8 @@ export interface PlayerStats {
 }
 
 export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
   if (!hasEspnCreds()) {
     return Response.json({ error: "ESPN_CREDS_MISSING" }, { status: 401 });
   }
@@ -46,6 +49,7 @@ export async function GET(req: Request) {
   const statusFilter = searchParams.get("status") ?? "ONTEAM";
 
   try {
+    const t0 = Date.now();
     const filters = {
       players: {
         filterStatus: { value: statusFilter === "ALL" ? ["FREEAGENT", "ONTEAM", "WAIVERS"] : ["ONTEAM"] },
@@ -137,9 +141,11 @@ export async function GET(req: Request) {
       });
     }
 
+    log.info({ op: "player-stats", count: players.length, durationMs: Date.now() - t0 }, "ok");
     return Response.json({ players, count: players.length });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    log.error({ op: "player-stats", err: msg }, "failed");
     return Response.json({ error: msg }, { status: 502 });
   }
 }

--- a/web/src/app/api/espn/power-rankings/route.ts
+++ b/web/src/app/api/espn/power-rankings/route.ts
@@ -1,6 +1,7 @@
 export const dynamic = "force-dynamic";
 import { espnFetch, hasEspnCreds, STAT_ID_MAP } from "@/lib/espn";
 import { getCategoryWeights } from "@/lib/data";
+import logger from "@/lib/logger";
 
 const MY_TEAM_ID = parseInt(process.env.MY_ESPN_TEAM_ID ?? "0");
 const CATS_ORDER = ["H", "R", "HR", "TB", "RBI", "BB", "SB", "AVG", "K", "QS", "W", "L", "SV", "HD", "ERA", "WHIP"];
@@ -191,7 +192,9 @@ function buildSnapshotForPeriod(
   return { teamStats, ranks, averages, composites, powerRanks, rawScores, weightedScores };
 }
 
-export async function GET() {
+export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
   if (!hasEspnCreds()) {
     return Response.json({ error: "ESPN_CREDS_MISSING" }, { status: 401 });
   }
@@ -200,6 +203,7 @@ export async function GET() {
   }
 
   try {
+    const t0 = Date.now();
     const [data, categoryWeights] = await Promise.all([
       espnFetch(["mMatchup", "mMatchupScore", "mTeam", "mStatus"]) as Promise<any>, // eslint-disable-line @typescript-eslint/no-explicit-any
       getCategoryWeights(),
@@ -274,6 +278,7 @@ export async function GET() {
       }))
       .sort((a, b) => a.powerRank - b.powerRank);
 
+    log.info({ op: "power-rankings", durationMs: Date.now() - t0 }, "ok");
     return Response.json({
       currentWeek: currentMatchupPeriod,
       myTeamId: MY_TEAM_ID,
@@ -281,6 +286,7 @@ export async function GET() {
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    log.error({ op: "power-rankings", err: msg }, "failed");
     return Response.json({ error: msg }, { status: 502 });
   }
 }

--- a/web/src/app/api/espn/roster/route.ts
+++ b/web/src/app/api/espn/roster/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = "force-dynamic";
 import { espnFetch, hasEspnCreds, SLOT_MAP, POS_MAP, INJURY_MAP, getProTeam } from "@/lib/espn";
+import logger from "@/lib/logger";
 
 export interface RosterPlayer {
   name: string;
@@ -63,16 +64,21 @@ function parseTeams(data: any): EspnTeam[] {
   return teams;
 }
 
-export async function GET() {
+export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
   if (!hasEspnCreds()) {
     return Response.json({ error: "ESPN_CREDS_MISSING" }, { status: 401 });
   }
   try {
+    const t0 = Date.now();
     const data = await espnFetch(["mRoster", "mTeam"]);
     const teams = parseTeams(data);
+    log.info({ op: "roster", durationMs: Date.now() - t0 }, "ok");
     return Response.json(teams);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    log.error({ op: "roster", err: msg }, "failed");
     return Response.json({ error: msg }, { status: 502 });
   }
 }

--- a/web/src/app/api/espn/schedule/route.ts
+++ b/web/src/app/api/espn/schedule/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = "force-dynamic";
 import { espnFetch, hasEspnCreds, getCurrentMatchupPeriod, buildMatchupSchedule, SEASON_START } from "@/lib/espn";
+import logger from "@/lib/logger";
 
 // Returns the full season schedule with matchup periods, dates, and opponents
 
@@ -21,7 +22,9 @@ export interface ScheduleData {
 
 const MY_TEAM_ID = parseInt(process.env.MY_ESPN_TEAM_ID ?? "0");
 
-export async function GET() {
+export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
   if (!hasEspnCreds()) {
     return Response.json({ error: "ESPN_CREDS_MISSING" }, { status: 401 });
   }
@@ -30,6 +33,7 @@ export async function GET() {
   }
 
   try {
+    const t0 = Date.now();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const data: any = await espnFetch(["mSettings", "mStatus", "mMatchup", "mTeam"]);
     const currentMatchupPeriod = getCurrentMatchupPeriod(data);
@@ -67,6 +71,7 @@ export async function GET() {
       };
     });
 
+    log.info({ op: "schedule", durationMs: Date.now() - t0 }, "ok");
     return Response.json({
       myTeamId: MY_TEAM_ID,
       currentMatchupPeriod,
@@ -75,6 +80,7 @@ export async function GET() {
     } as ScheduleData);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    log.error({ op: "schedule", err: msg }, "failed");
     return Response.json({ error: msg }, { status: 502 });
   }
 }

--- a/web/src/app/api/espn/scoreboard/route.ts
+++ b/web/src/app/api/espn/scoreboard/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = "force-dynamic";
 import { espnFetch, hasEspnCreds, STAT_ID_MAP } from "@/lib/espn";
+import logger from "@/lib/logger";
 
 export interface ScoreboardCatResult {
   cat: string;
@@ -32,11 +33,14 @@ export interface ScoreboardData {
 const MY_TEAM_ID = parseInt(process.env.MY_ESPN_TEAM_ID ?? "0");
 const CATS_ORDER = ["H", "R", "HR", "TB", "RBI", "BB", "SB", "AVG", "K", "QS", "W", "L", "SV", "HD", "ERA", "WHIP"];
 
-export async function GET() {
+export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
   if (!hasEspnCreds()) {
     return Response.json({ error: "ESPN_CREDS_MISSING" }, { status: 401 });
   }
   try {
+    const t0 = Date.now();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const data: any = await espnFetch(["mMatchup", "mMatchupScore", "mTeam", "mStatus"]);
     const currentMatchupPeriod = (data as any).status?.currentMatchupPeriod ?? 1;
@@ -96,9 +100,11 @@ export async function GET() {
       };
     });
 
+    log.info({ op: "scoreboard", durationMs: Date.now() - t0 }, "ok");
     return Response.json({ currentMatchupPeriod, myTeamId: MY_TEAM_ID, matchups } as ScoreboardData);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    log.error({ op: "scoreboard", err: msg }, "failed");
     return Response.json({ error: msg }, { status: 502 });
   }
 }

--- a/web/src/app/api/espn/standings/route.ts
+++ b/web/src/app/api/espn/standings/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = "force-dynamic";
 import { espnFetch, hasEspnCreds } from "@/lib/espn";
+import logger from "@/lib/logger";
 
 export interface StandingsTeam {
   teamId: number;
@@ -26,7 +27,9 @@ export interface StandingsData {
 
 const MY_TEAM_ID = parseInt(process.env.MY_ESPN_TEAM_ID ?? "0");
 
-export async function GET() {
+export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
   if (!hasEspnCreds()) {
     return Response.json({ error: "ESPN_CREDS_MISSING" }, { status: 401 });
   }
@@ -35,6 +38,7 @@ export async function GET() {
   }
 
   try {
+    const t0 = Date.now();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const data: any = await espnFetch(["mTeam", "mStatus", "mSettings", "mMatchup", "mMatchupScore"]);
     const currentMatchupPeriod = (data as any).status?.currentMatchupPeriod ?? 1;
@@ -91,6 +95,7 @@ export async function GET() {
     // Assign ranks
     teams.forEach((t, i) => { if (!t.rank) t.rank = i + 1; });
 
+    log.info({ op: "standings", durationMs: Date.now() - t0 }, "ok");
     return Response.json({
       currentMatchupPeriod,
       totalMatchupPeriods,
@@ -99,6 +104,7 @@ export async function GET() {
     } as StandingsData);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    log.error({ op: "standings", err: msg }, "failed");
     return Response.json({ error: msg }, { status: 502 });
   }
 }

--- a/web/src/app/api/espn/starts/route.ts
+++ b/web/src/app/api/espn/starts/route.ts
@@ -1,5 +1,6 @@
 export const dynamic = "force-dynamic";
 import { espnFetch, hasEspnCreds, POS_MAP, getProTeam, getMatchupDates, getCurrentMatchupPeriod } from "@/lib/espn";
+import logger from "@/lib/logger";
 
 export interface StartsTeam {
   teamId: number;
@@ -52,7 +53,9 @@ async function buildGameIdDateMap(startDate: string, endDate: string): Promise<R
   }
 }
 
-export async function GET() {
+export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
   if (!hasEspnCreds()) {
     return Response.json({ error: "ESPN_CREDS_MISSING" }, { status: 401 });
   }
@@ -61,6 +64,7 @@ export async function GET() {
   }
 
   try {
+    const t0 = Date.now();
     const data: any = await espnFetch(["mRoster", "mTeam", "mStatus", "mSettings"]);
     const currentMatchupPeriod = getCurrentMatchupPeriod(data);
     const currentDates = getMatchupDates(data, currentMatchupPeriod);
@@ -123,6 +127,7 @@ export async function GET() {
       teams.push({ teamId: t.id, teamName: name, pitchers });
     }
 
+    log.info({ op: "starts", durationMs: Date.now() - t0 }, "ok");
     return Response.json({
       myTeamId: MY_TEAM_ID,
       currentMatchupPeriod,
@@ -133,6 +138,7 @@ export async function GET() {
     } as StartsData);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    log.error({ op: "starts", err: msg }, "failed");
     return Response.json({ error: msg }, { status: 502 });
   }
 }

--- a/web/src/app/api/mlb/bvp/route.ts
+++ b/web/src/app/api/mlb/bvp/route.ts
@@ -1,5 +1,6 @@
 // MLB Stats API — batter vs pitcher career stats
 // Takes batter and pitcher names, looks up IDs, returns career matchup stats
+import logger from "@/lib/logger";
 
 export interface BvpStats {
   batter: string;
@@ -79,6 +80,8 @@ async function fetchBvp(batterId: number, pitcherId: number): Promise<any | null
 }
 
 export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
   const { searchParams } = new URL(req.url);
   const matchups = searchParams.get("matchups"); // JSON array of { batter, pitcher } pairs
 
@@ -87,6 +90,7 @@ export async function GET(req: Request) {
   }
 
   try {
+    const t0 = Date.now();
     const pairs: { batter: string; pitcher: string }[] = JSON.parse(matchups);
     if (!Array.isArray(pairs) || pairs.length === 0) {
       return Response.json({ error: "Invalid matchups" }, { status: 400 });
@@ -146,8 +150,10 @@ export async function GET(req: Request) {
       })
     );
 
+    log.info({ op: "bvp", count: results.length, durationMs: Date.now() - t0 }, "ok");
     return Response.json(results);
   } catch (err) {
+    log.error({ op: "bvp", err: String(err) }, "failed");
     return Response.json({ error: String(err) }, { status: 502 });
   }
 }

--- a/web/src/app/api/mlb/probable-pitchers/route.ts
+++ b/web/src/app/api/mlb/probable-pitchers/route.ts
@@ -1,6 +1,7 @@
 // MLB Stats API — probable pitcher schedule
 // Returns scheduled starts per pitcher for a date range
 // Public API, no auth required
+import logger from "@/lib/logger";
 
 export interface ProbableStart {
   date: string;          // "2026-03-30"
@@ -57,6 +58,8 @@ function toET(utcDate: string): string {
 }
 
 export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
   const { searchParams } = new URL(req.url);
   const today = new Date().toISOString().slice(0, 10);
   const startDate = searchParams.get("startDate") ?? today;
@@ -65,6 +68,7 @@ export async function GET(req: Request) {
   const endDate = searchParams.get("endDate") ?? defaultEnd.toISOString().slice(0, 10);
 
   try {
+    const t0 = Date.now();
     const url = `https://statsapi.mlb.com/api/v1/schedule?sportId=1&startDate=${startDate}&endDate=${endDate}&gameType=R&hydrate=probablePitcher,team`;
     const res = await fetch(url, { next: { revalidate: 900 } }); // 15 min cache
     if (!res.ok) return Response.json({ error: "MLB_API_FAILED" }, { status: 502 });
@@ -108,8 +112,10 @@ export async function GET(req: Request) {
     // Sort all starts chronologically
     allStarts.sort((a, b) => a.date.localeCompare(b.date));
 
+    log.info({ op: "probable-pitchers", count: allStarts.length, durationMs: Date.now() - t0 }, "ok");
     return Response.json({ startDate, endDate, byPitcher, allStarts } as ProbablePitchersData);
   } catch (err) {
+    log.error({ op: "probable-pitchers", err: String(err) }, "failed");
     return Response.json({ error: String(err) }, { status: 502 });
   }
 }

--- a/web/src/app/api/mlb/schedule-grid/route.ts
+++ b/web/src/app/api/mlb/schedule-grid/route.ts
@@ -1,5 +1,6 @@
 // MLB Stats API — per-day schedule grid
 // Returns opponent for each team on each day in the date range
+import logger from "@/lib/logger";
 
 const TEAM_MAP: Record<string, string> = {
   AZ: "ARI", ARI: "ARI", WSH: "WSH", WAS: "WSH",
@@ -18,6 +19,8 @@ function normalize(abbrev: string): string {
 export type ScheduleGrid = Record<string, Record<string, string>>;
 
 export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
   const { searchParams } = new URL(req.url);
   const startDate = searchParams.get("startDate");
   const endDate = searchParams.get("endDate");
@@ -27,6 +30,7 @@ export async function GET(req: Request) {
   }
 
   try {
+    const t0 = Date.now();
     const url = `https://statsapi.mlb.com/api/v1/schedule?sportId=1&startDate=${startDate}&endDate=${endDate}&gameType=R&hydrate=team`;
     const res = await fetch(url, { next: { revalidate: 900 } });
     if (!res.ok) return Response.json({ error: "MLB_API_FAILED" }, { status: 502 });
@@ -49,8 +53,10 @@ export async function GET(req: Request) {
       }
     }
 
+    log.info({ op: "schedule-grid", durationMs: Date.now() - t0 }, "ok");
     return Response.json(grid);
   } catch (err) {
+    log.error({ op: "schedule-grid", err: String(err) }, "failed");
     return Response.json({ error: String(err) }, { status: 502 });
   }
 }

--- a/web/src/app/api/mlb/schedule/route.ts
+++ b/web/src/app/api/mlb/schedule/route.ts
@@ -1,5 +1,6 @@
 // MLB Stats API — public, no auth required
 // Returns today's games per team with opponent, time, probable pitcher, venue
+import logger from "@/lib/logger";
 
 export interface TeamSchedule {
   todayOpponent: string | null;       // e.g. "@NYY" or "vs LAD"
@@ -52,12 +53,15 @@ function addDays(date: Date, n: number): string {
 }
 
 export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
   const { searchParams } = new URL(req.url);
   const startDate = searchParams.get("startDate") ?? new Date().toISOString().slice(0, 10);
   const endDate = searchParams.get("endDate") ?? addDays(new Date(startDate), 13);
   const today = new Date().toISOString().slice(0, 10);
 
   try {
+    const t0 = Date.now();
     const url = `https://statsapi.mlb.com/api/v1/schedule?sportId=1&startDate=${startDate}&endDate=${endDate}&gameType=R&hydrate=probablePitcher,team,venue`;
     const res = await fetch(url, { next: { revalidate: 900 } });
     if (!res.ok) return Response.json({ error: "MLB_API_FAILED" }, { status: 502 });
@@ -98,8 +102,10 @@ export async function GET(req: Request) {
       }
     }
 
+    log.info({ op: "mlb-schedule", durationMs: Date.now() - t0 }, "ok");
     return Response.json(schedule);
   } catch (err) {
+    log.error({ op: "mlb-schedule", err: String(err) }, "failed");
     return Response.json({ error: String(err) }, { status: 502 });
   }
 }

--- a/web/src/app/api/owners/route.ts
+++ b/web/src/app/api/owners/route.ts
@@ -1,5 +1,11 @@
 import { getOwnerSeasons } from "@/lib/data";
+import logger from "@/lib/logger";
 
-export async function GET() {
-  return Response.json(await getOwnerSeasons());
+export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
+  const t0 = Date.now();
+  const data = await getOwnerSeasons();
+  log.info({ op: "owners", durationMs: Date.now() - t0 }, "ok");
+  return Response.json(data);
 }

--- a/web/src/app/api/player-positions/route.ts
+++ b/web/src/app/api/player-positions/route.ts
@@ -1,5 +1,11 @@
 import { getPlayerPositions } from "@/lib/data";
+import logger from "@/lib/logger";
 
-export async function GET() {
-  return Response.json(await getPlayerPositions());
+export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
+  const t0 = Date.now();
+  const data = await getPlayerPositions();
+  log.info({ op: "player-positions", durationMs: Date.now() - t0 }, "ok");
+  return Response.json(data);
 }

--- a/web/src/app/api/profiles/route.ts
+++ b/web/src/app/api/profiles/route.ts
@@ -1,5 +1,11 @@
 import { getDraftProfiles } from "@/lib/data";
+import logger from "@/lib/logger";
 
-export async function GET() {
-  return Response.json(await getDraftProfiles());
+export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
+  const t0 = Date.now();
+  const data = await getDraftProfiles();
+  log.info({ op: "profiles", durationMs: Date.now() - t0 }, "ok");
+  return Response.json(data);
 }

--- a/web/src/app/api/rankings/route.ts
+++ b/web/src/app/api/rankings/route.ts
@@ -1,5 +1,11 @@
 import { getRankings } from "@/lib/data";
+import logger from "@/lib/logger";
 
-export async function GET() {
-  return Response.json(await getRankings());
+export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
+  const t0 = Date.now();
+  const data = await getRankings();
+  log.info({ op: "rankings", durationMs: Date.now() - t0 }, "ok");
+  return Response.json(data);
 }

--- a/web/src/app/api/standings/route.ts
+++ b/web/src/app/api/standings/route.ts
@@ -1,5 +1,11 @@
 import { getAllStandings } from "@/lib/data";
+import logger from "@/lib/logger";
 
-export async function GET() {
-  return Response.json(await getAllStandings());
+export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
+  const t0 = Date.now();
+  const data = await getAllStandings();
+  log.info({ op: "standings-data", durationMs: Date.now() - t0 }, "ok");
+  return Response.json(data);
 }

--- a/web/src/app/api/weights/route.ts
+++ b/web/src/app/api/weights/route.ts
@@ -1,7 +1,12 @@
 import { getCategoryWeights } from "@/lib/data";
+import logger from "@/lib/logger";
 
-export async function GET() {
+export async function GET(req: Request) {
+  const reqId = crypto.randomUUID();
+  const log = logger.child({ reqId, path: new URL(req.url).pathname });
+  const t0 = Date.now();
   const data = await getCategoryWeights();
   if (!data) return Response.json({ error: "No weights data" }, { status: 404 });
+  log.info({ op: "weights", durationMs: Date.now() - t0 }, "ok");
   return Response.json(data);
 }

--- a/web/src/lib/espn.ts
+++ b/web/src/lib/espn.ts
@@ -1,5 +1,6 @@
 // ESPN private league API client
 // Requires ESPN_S2 and ESPN_SWID environment variables (Vercel env vars)
+import logger from "@/lib/logger";
 
 const LEAGUE_ID = 4739;
 const SEASON = 2026;
@@ -17,6 +18,7 @@ export async function espnFetch(views: string[], extra: string = ""): Promise<un
   const viewParams = views.map((v) => `view=${v}`).join("&");
   const url = `${BASE}?${viewParams}${extra}`;
 
+  const t0 = Date.now();
   const res = await fetch(url, {
     headers: {
       Cookie: `espn_s2=${espnS2}; SWID=${swid}`,
@@ -25,8 +27,13 @@ export async function espnFetch(views: string[], extra: string = ""): Promise<un
     },
     cache: "no-store",
   });
+  const durationMs = Date.now() - t0;
 
-  if (!res.ok) throw new Error(`ESPN API ${res.status}`);
+  if (!res.ok) {
+    logger.error({ op: "espn_fetch", views, status: res.status, durationMs }, "ESPN API error");
+    throw new Error(`ESPN API ${res.status}`);
+  }
+  logger.info({ op: "espn_fetch", views, durationMs }, "ESPN fetch ok");
   return res.json();
 }
 

--- a/web/src/lib/logger.ts
+++ b/web/src/lib/logger.ts
@@ -1,0 +1,9 @@
+import pino from "pino";
+
+const logger = pino(
+  process.env.NODE_ENV === "production"
+    ? {}
+    : { transport: { target: "pino-pretty" } }
+);
+
+export default logger;


### PR DESCRIPTION
Closes #16

## Changes

- **`web/src/lib/logger.ts`** (new): singleton pino logger — JSON output in production, pino-pretty in development
- **`web/next.config.ts`**: added `serverExternalPackages: ["pino", "pino-pretty"]` to prevent webpack bundling
- **`web/package.json`**: added `pino` and `pino-pretty` dependencies
- **`web/src/lib/espn.ts`**: added timing around `fetch` in `espnFetch`, logging `{op, views, status, durationMs}` on success and error
- **All 26 API route handlers**: each now generates `const reqId = crypto.randomUUID()` and a `logger.child({ reqId, path })` instance; logs `{op, durationMs}` on completion and `{op, err}` on failure

## Verification

- All 46 tests pass
- `npx tsc --noEmit` exits clean