### PR TITLE
Add per-category team rankings to Scoreboard page

### DIFF
--- a/web/src/app/league/scoreboard/page.tsx
+++ b/web/src/app/league/scoreboard/page.tsx
@@ -29,6 +29,61 @@ interface ScoreboardData {
   matchups: ScoreboardMatchup[];
 }
 
+export interface TeamCatValues {
+  teamId: number;
+  teamName: string;
+  values: Record<string, number>;
+}
+
+const LOWER_IS_BETTER = new Set(["ERA", "WHIP", "L"]);
+
+export function sanitizeCatVal(v: unknown): number {
+  if (typeof v !== "number" || !Number.isFinite(v)) return 0;
+  return v;
+}
+
+export function buildTeamCatValues(matchups: ScoreboardMatchup[]): TeamCatValues[] {
+  const teams: Record<number, TeamCatValues> = {};
+  for (const m of matchups) {
+    if (!teams[m.homeTeamId]) {
+      teams[m.homeTeamId] = { teamId: m.homeTeamId, teamName: m.homeTeamName, values: {} };
+    }
+    if (!teams[m.awayTeamId]) {
+      teams[m.awayTeamId] = { teamId: m.awayTeamId, teamName: m.awayTeamName, values: {} };
+    }
+    for (const c of m.categories ?? []) {
+      teams[m.homeTeamId].values[c.cat] = sanitizeCatVal(c.homeValue);
+      teams[m.awayTeamId].values[c.cat] = sanitizeCatVal(c.awayValue);
+    }
+  }
+  return Object.values(teams);
+}
+
+// Returns a map of teamId -> rank (1 = best) for the given category.
+// Tied teams receive the same rank; the next rank skips accordingly.
+export function rankByCategory(teams: TeamCatValues[], cat: string): Record<number, number> {
+  const lowerIsBetter = LOWER_IS_BETTER.has(cat);
+  const sorted = [...teams]
+    .map((t) => ({ teamId: t.teamId, val: sanitizeCatVal(t.values[cat]) }))
+    .sort((a, b) => (lowerIsBetter ? a.val - b.val : b.val - a.val));
+
+  const result: Record<number, number> = {};
+  let rank = 1;
+  for (let i = 0; i < sorted.length; i++) {
+    if (i > 0 && sorted[i].val !== sorted[i - 1].val) {
+      rank = i + 1;
+    }
+    result[sorted[i].teamId] = rank;
+  }
+  return result;
+}
+
+function rankColor(rank: number): string {
+  if (rank <= 3) return "bg-emerald-100 text-emerald-800";
+  if (rank >= 8) return "bg-red-100 text-red-800";
+  return "bg-amber-50 text-amber-800";
+}
+
 function fmtCatVal(cat: string, val: number): string {
   if (cat === "AVG") return val.toFixed(3);
   if (cat === "ERA" || cat === "WHIP") return val.toFixed(2);
@@ -46,6 +101,70 @@ function EspnSetupCard() {
     <div className="mx-auto max-w-lg rounded-xl border border-border bg-surface px-8 py-10 text-center">
       <div className="text-[11px] font-semibold uppercase tracking-widest text-orange-600/60">Setup Required</div>
       <div className="mt-3 text-xl font-bold text-gray-900">Connect ESPN Credentials</div>
+    </div>
+  );
+}
+
+interface CategoryRankingsGridProps {
+  matchups: ScoreboardMatchup[];
+  myTeamId: number;
+}
+
+function CategoryRankingsGrid({ matchups, myTeamId }: CategoryRankingsGridProps) {
+  const teams = buildTeamCatValues(matchups);
+  if (teams.length === 0) return null;
+
+  const cats = matchups[0]?.categories?.map((c) => c.cat) ?? [];
+  const rankMaps: Record<string, Record<number, number>> = {};
+  for (const cat of cats) {
+    rankMaps[cat] = rankByCategory(teams, cat);
+  }
+
+  const sorted = [...teams].sort((a, b) => a.teamName.localeCompare(b.teamName));
+
+  return (
+    <div className="mt-6">
+      <h2 className="mb-2 text-[13px] font-semibold text-slate-700">Category Rankings</h2>
+      <div className="overflow-x-auto rounded-lg border border-border bg-surface">
+        <table className="w-full text-[11px]">
+          <thead>
+            <tr className="border-b border-border bg-slate-50">
+              <th className="px-3 py-2 text-left font-semibold text-slate-500 whitespace-nowrap">Team</th>
+              {cats.map((cat) => (
+                <th key={cat} className="px-1.5 py-2 text-center font-semibold text-slate-500 whitespace-nowrap">
+                  {cat}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((team) => {
+              const isMyTeam = team.teamId === myTeamId;
+              return (
+                <tr
+                  key={team.teamId}
+                  className={`border-b border-border/50 last:border-0 ${isMyTeam ? "bg-orange-50" : ""}`}
+                >
+                  <td className={`px-3 py-1.5 whitespace-nowrap font-medium ${isMyTeam ? "text-orange-600" : "text-slate-700"}`}>
+                    {isMyTeam && <span className="mr-1.5 inline-block h-1.5 w-1.5 rounded-full bg-orange-500 align-middle" />}
+                    {team.teamName}
+                  </td>
+                  {cats.map((cat) => {
+                    const rank = rankMaps[cat]?.[team.teamId] ?? 0;
+                    return (
+                      <td key={cat} className="px-1 py-1.5 text-center">
+                        <span className={`inline-block min-w-[22px] rounded px-1 py-0.5 font-mono tabular-nums font-semibold ${rankColor(rank)}`}>
+                          {rank}
+                        </span>
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }
@@ -92,7 +211,6 @@ export default function ScoreboardPage() {
           const isMyMatchup = m.homeTeamId === data.myTeamId || m.awayTeamId === data.myTeamId;
           const homeLeading = m.homeWins > m.homeLosses;
           const awayLeading = m.awayWins > m.awayLosses;
-          const tied = m.homeWins === m.homeLosses;
 
           const isExpanded = expanded === i;
           return (
@@ -160,6 +278,10 @@ export default function ScoreboardPage() {
         <div className="rounded-lg border border-border bg-surface px-6 py-10 text-center text-slate-500">
           No matchups found for this week.
         </div>
+      )}
+
+      {data.matchups.length > 0 && (
+        <CategoryRankingsGrid matchups={data.matchups} myTeamId={data.myTeamId} />
       )}
     </div>
   );

--- a/web/src/tests/scoreboard.test.ts
+++ b/web/src/tests/scoreboard.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import {
+  sanitizeCatVal,
+  buildTeamCatValues,
+  rankByCategory,
+  type TeamCatValues,
+} from "@/app/league/scoreboard/page";
+
+describe("sanitizeCatVal", () => {
+  it("passes through finite numbers", () => {
+    expect(sanitizeCatVal(42)).toBe(42);
+    expect(sanitizeCatVal(0)).toBe(0);
+    expect(sanitizeCatVal(-5)).toBe(-5);
+  });
+
+  it("returns 0 for NaN", () => {
+    expect(sanitizeCatVal(NaN)).toBe(0);
+  });
+
+  it("returns 0 for Infinity", () => {
+    expect(sanitizeCatVal(Infinity)).toBe(0);
+    expect(sanitizeCatVal(-Infinity)).toBe(0);
+  });
+
+  it("returns 0 for null", () => {
+    expect(sanitizeCatVal(null)).toBe(0);
+  });
+
+  it("returns 0 for undefined", () => {
+    expect(sanitizeCatVal(undefined)).toBe(0);
+  });
+
+  it("returns 0 for non-number types", () => {
+    expect(sanitizeCatVal("50")).toBe(0);
+  });
+});
+
+describe("rankByCategory — basic sort", () => {
+  const teams: TeamCatValues[] = [
+    { teamId: 1, teamName: "A", values: { HR: 30 } },
+    { teamId: 2, teamName: "B", values: { HR: 50 } },
+    { teamId: 3, teamName: "C", values: { HR: 40 } },
+  ];
+
+  it("assigns rank 1 to the team with the highest value for higher-is-better cats", () => {
+    const ranks = rankByCategory(teams, "HR");
+    expect(ranks[2]).toBe(1);
+    expect(ranks[3]).toBe(2);
+    expect(ranks[1]).toBe(3);
+  });
+
+  it("assigns rank 1 to the team with the lowest ERA (lower-is-better)", () => {
+    const eraTeams: TeamCatValues[] = [
+      { teamId: 1, teamName: "A", values: { ERA: 4.5 } },
+      { teamId: 2, teamName: "B", values: { ERA: 2.1 } },
+      { teamId: 3, teamName: "C", values: { ERA: 3.3 } },
+    ];
+    const ranks = rankByCategory(eraTeams, "ERA");
+    expect(ranks[2]).toBe(1);
+    expect(ranks[3]).toBe(2);
+    expect(ranks[1]).toBe(3);
+  });
+});
+
+describe("rankByCategory — tie handling", () => {
+  it("assigns the same rank to tied teams", () => {
+    const teams: TeamCatValues[] = [
+      { teamId: 1, teamName: "A", values: { HR: 40 } },
+      { teamId: 2, teamName: "B", values: { HR: 40 } },
+      { teamId: 3, teamName: "C", values: { HR: 30 } },
+    ];
+    const ranks = rankByCategory(teams, "HR");
+    expect(ranks[1]).toBe(1);
+    expect(ranks[2]).toBe(1);
+    expect(ranks[3]).toBe(3);
+  });
+
+  it("skips the rank after a tie (standard ranking, not dense)", () => {
+    const teams: TeamCatValues[] = [
+      { teamId: 1, teamName: "A", values: { HR: 50 } },
+      { teamId: 2, teamName: "B", values: { HR: 50 } },
+      { teamId: 3, teamName: "C", values: { HR: 50 } },
+      { teamId: 4, teamName: "D", values: { HR: 20 } },
+    ];
+    const ranks = rankByCategory(teams, "HR");
+    expect(ranks[1]).toBe(1);
+    expect(ranks[2]).toBe(1);
+    expect(ranks[3]).toBe(1);
+    expect(ranks[4]).toBe(4);
+  });
+
+  it("handles all teams tied", () => {
+    const teams: TeamCatValues[] = [
+      { teamId: 1, teamName: "A", values: { SB: 10 } },
+      { teamId: 2, teamName: "B", values: { SB: 10 } },
+    ];
+    const ranks = rankByCategory(teams, "SB");
+    expect(ranks[1]).toBe(1);
+    expect(ranks[2]).toBe(1);
+  });
+});
+
+describe("buildTeamCatValues", () => {
+  it("extracts home and away team values from matchups", () => {
+    const matchups = [
+      {
+        homeTeamId: 1,
+        homeTeamName: "Home",
+        homeWins: 5,
+        homeLosses: 3,
+        homeTies: 0,
+        awayTeamId: 2,
+        awayTeamName: "Away",
+        awayWins: 3,
+        awayLosses: 5,
+        awayTies: 0,
+        categories: [
+          { cat: "HR", homeValue: 10, awayValue: 7, result: "HOME" as const },
+        ],
+      },
+    ];
+    const teams = buildTeamCatValues(matchups);
+    expect(teams).toHaveLength(2);
+    const home = teams.find((t) => t.teamId === 1);
+    const away = teams.find((t) => t.teamId === 2);
+    expect(home?.values.HR).toBe(10);
+    expect(away?.values.HR).toBe(7);
+  });
+
+  it("sanitizes NaN and Infinity in category values", () => {
+    const matchups = [
+      {
+        homeTeamId: 1,
+        homeTeamName: "Home",
+        homeWins: 0,
+        homeLosses: 0,
+        homeTies: 0,
+        awayTeamId: 2,
+        awayTeamName: "Away",
+        awayWins: 0,
+        awayLosses: 0,
+        awayTies: 0,
+        categories: [
+          { cat: "ERA", homeValue: NaN, awayValue: Infinity, result: "TIE" as const },
+        ],
+      },
+    ];
+    const teams = buildTeamCatValues(matchups);
+    const home = teams.find((t) => t.teamId === 1);
+    const away = teams.find((t) => t.teamId === 2);
+    expect(home?.values.ERA).toBe(0);
+    expect(away?.values.ERA).toBe(0);
+  });
+
+  it("returns empty array for no matchups", () => {
+    expect(buildTeamCatValues([])).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #18

## Changes

- Added `sanitizeCatVal`, `buildTeamCatValues`, and `rankByCategory` pure utility functions (exported for testing) to `web/src/app/league/scoreboard/page.tsx`
- Added `CategoryRankingsGrid` component rendering a scrollable table below matchup results: rows are teams (alpha sorted), columns are scoring categories
- Heatmap: rank 1-3 green, rank 4-7 yellow/amber, rank 8-10 red
- User's team row highlighted in orange with dot indicator
- Lower-is-better categories (ERA, WHIP, L) ranked in reverse
- Sanitizes NaN, Infinity, null before ranking (treated as 0)
- Ties use standard ranking (1224 style): tied teams share a rank, next position skips
- Removed pre-existing unused `tied` variable that caused a lint warning
- Created `web/src/tests/scoreboard.test.ts` with 14 Vitest tests covering basic sort, lower-is-better, tie-handling edge cases, sanitization, and `buildTeamCatValues`

## Test results

60 tests pass (was 46 before this PR). TypeScript and ESLint clean.