### PR TITLE
Add matchup strength indicator to Schedule page

### DIFF
--- a/web/src/app/league/schedule/page.tsx
+++ b/web/src/app/league/schedule/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import { mean, stddev } from "@/lib/z-scores";
 
 interface MatchupWeek {
   period: number;
@@ -23,6 +24,49 @@ interface TeamRankInfo {
   compositeAvgRank: number;
 }
 
+const CATS = ["H", "R", "HR", "TB", "RBI", "BB", "SB", "AVG", "K", "QS", "W", "L", "SV", "HD", "ERA", "WHIP"] as const;
+const LOWER_IS_BETTER_CATS = new Set(["ERA", "WHIP", "L"]);
+
+export function buildZScoreMap(
+  teams: Array<{ teamId: number; categories: Record<string, number> }>,
+  averages: Record<string, number>,
+): Record<number, Record<string, number>> {
+  const zMap: Record<number, Record<string, number>> = {};
+  for (const cat of CATS) {
+    const vals = teams.map((t) => t.categories[cat] ?? 0);
+    const mu = averages[cat] ?? mean(vals);
+    const sd = stddev(vals, mu);
+    for (const team of teams) {
+      if (!zMap[team.teamId]) zMap[team.teamId] = {};
+      const raw = ((team.categories[cat] ?? 0) - mu) / sd;
+      zMap[team.teamId][cat] = LOWER_IS_BETTER_CATS.has(cat) ? -raw : raw;
+    }
+  }
+  return zMap;
+}
+
+export function computeMatchupStrength(
+  myZ: Record<string, number>,
+  oppZ: Record<string, number>,
+): { score: number; topCategories: string[] } {
+  const diffs = CATS.map((cat) => ({
+    cat,
+    diff: (oppZ[cat] ?? 0) - (myZ[cat] ?? 0),
+  }));
+  const score = mean(diffs.map((d) => d.diff));
+  const topCategories = [...diffs]
+    .sort((a, b) => Math.abs(b.diff) - Math.abs(a.diff))
+    .slice(0, 2)
+    .map((d) => d.cat);
+  return { score, topCategories };
+}
+
+function strengthStyle(score: number): { label: string; color: string } {
+  if (score < -0.3) return { label: "Favorable", color: "text-emerald-600 bg-emerald-50 border-emerald-200" };
+  if (score > 0.3) return { label: "Tough", color: "text-red-600 bg-red-50 border-red-200" };
+  return { label: "Even", color: "text-yellow-600 bg-yellow-50 border-yellow-200" };
+}
+
 function difficultyLabel(rank: number): { label: string; color: string } {
   if (rank <= 2) return { label: "Hard", color: "text-red-600 bg-red-50 border-red-200" };
   if (rank <= 4) return { label: "Tough", color: "text-orange-600 bg-orange-50 border-orange-200" };
@@ -34,10 +78,6 @@ function fmtDateRange(start: string, end: string): string {
   const s = new Date(start + "T12:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" });
   const e = new Date(end + "T12:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" });
   return `${s} – ${e}`;
-}
-
-function fmtDate(d: string): string {
-  return new Date(d + "T12:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
 
 function EspnSetupCard() {
@@ -52,6 +92,7 @@ function EspnSetupCard() {
 export default function SchedulePage() {
   const [data, setData] = useState<ScheduleData | null>(null);
   const [teamRanks, setTeamRanks] = useState<Record<number, TeamRankInfo>>({});
+  const [zScoreMap, setZScoreMap] = useState<Record<number, Record<string, number>>>({});
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const currentRef = useRef<HTMLDivElement>(null);
@@ -69,6 +110,9 @@ export default function SchedulePage() {
           ranks[t.teamId] = { powerRank: t.powerRank, compositeAvgRank: t.compositeAvgRank };
         }
         setTeamRanks(ranks);
+        if (leagueData.averages) {
+          setZScoreMap(buildZScoreMap(leagueData.teams, leagueData.averages));
+        }
       }
     })
     .catch(() => setError("FETCH_FAILED"))
@@ -97,8 +141,6 @@ export default function SchedulePage() {
 
   // Split into past, current, future
   const pastWeeks = data.weeks.filter((w) => w.period < data.currentMatchupPeriod);
-  const currentWeek = data.weeks.find((w) => w.isCurrent);
-  const futureWeeks = data.weeks.filter((w) => w.period > data.currentMatchupPeriod);
   const totalWeeks = data.weeks.length;
   const weeksCompleted = pastWeeks.length;
 
@@ -117,6 +159,11 @@ export default function SchedulePage() {
         {data.weeks.map((week) => {
           const isPast = week.period < data.currentMatchupPeriod;
           const isCurrent = week.isCurrent;
+
+          const myZ = zScoreMap[data.myTeamId];
+          const oppZ = week.myOpponentId != null ? zScoreMap[week.myOpponentId] : undefined;
+          const strength = myZ && oppZ ? computeMatchupStrength(myZ, oppZ) : null;
+          const style = strength ? strengthStyle(strength.score) : null;
 
           return (
             <div
@@ -149,6 +196,14 @@ export default function SchedulePage() {
                     {week.myOpponentId && teamRanks[week.myOpponentId] && (
                       <span className={`text-[9px] font-bold border rounded px-1.5 py-0.5 ${difficultyLabel(teamRanks[week.myOpponentId].powerRank).color}`}>
                         #{teamRanks[week.myOpponentId].powerRank} {difficultyLabel(teamRanks[week.myOpponentId].powerRank).label}
+                      </span>
+                    )}
+                    {strength && style && (
+                      <span
+                        title={`Top factors: ${strength.topCategories.join(", ")}`}
+                        className={`text-[9px] font-bold border rounded px-1.5 py-0.5 cursor-help ${style.color}`}
+                      >
+                        {style.label}
                       </span>
                     )}
                   </>

--- a/web/src/tests/schedule.test.ts
+++ b/web/src/tests/schedule.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { computeMatchupStrength, buildZScoreMap } from "@/app/league/schedule/page";
+
+const ALL_CATS = ["H", "R", "HR", "TB", "RBI", "BB", "SB", "AVG", "K", "QS", "W", "L", "SV", "HD", "ERA", "WHIP"];
+
+function zeroZ(): Record<string, number> {
+  return Object.fromEntries(ALL_CATS.map((c) => [c, 0]));
+}
+
+describe("computeMatchupStrength", () => {
+  it("returns score near 0 when both teams have identical z-scores", () => {
+    const z = zeroZ();
+    const result = computeMatchupStrength(z, z);
+    expect(result.score).toBe(0);
+  });
+
+  it("returns negative score (favorable) when I am stronger in all categories", () => {
+    const myZ = Object.fromEntries(ALL_CATS.map((c) => [c, 1.0]));
+    const oppZ = zeroZ();
+    const result = computeMatchupStrength(myZ, oppZ);
+    expect(result.score).toBeLessThan(-0.3);
+  });
+
+  it("returns positive score (tough) when opponent is stronger in all categories", () => {
+    const myZ = zeroZ();
+    const oppZ = Object.fromEntries(ALL_CATS.map((c) => [c, 1.0]));
+    const result = computeMatchupStrength(myZ, oppZ);
+    expect(result.score).toBeGreaterThan(0.3);
+  });
+
+  it("returns exactly 2 top categories", () => {
+    const myZ = zeroZ();
+    const oppZ = Object.fromEntries(ALL_CATS.map((c, i) => [c, i * 0.1]));
+    const result = computeMatchupStrength(myZ, oppZ);
+    expect(result.topCategories).toHaveLength(2);
+  });
+
+  it("treats missing z-scores as 0", () => {
+    const myZ: Record<string, number> = {};
+    const oppZ: Record<string, number> = {};
+    const result = computeMatchupStrength(myZ, oppZ);
+    expect(result.score).toBe(0);
+    expect(Number.isFinite(result.score)).toBe(true);
+  });
+
+  it("mixed-category fixture: computes score correctly", () => {
+    // Opponent is better in half, I am better in half — should be near zero
+    const myZ: Record<string, number> = {};
+    const oppZ: Record<string, number> = {};
+    for (let i = 0; i < ALL_CATS.length; i++) {
+      const cat = ALL_CATS[i];
+      myZ[cat] = i % 2 === 0 ? 1.0 : -1.0;
+      oppZ[cat] = i % 2 === 0 ? -1.0 : 1.0;
+    }
+    const result = computeMatchupStrength(myZ, oppZ);
+    expect(result.score).toBeCloseTo(0, 5);
+  });
+
+  it("top categories are the ones with the largest absolute differential", () => {
+    const myZ = zeroZ();
+    const oppZ = { ...zeroZ(), ERA: 3.0, HR: 2.5, WHIP: 0.1 };
+    const result = computeMatchupStrength(myZ, oppZ);
+    expect(result.topCategories).toContain("ERA");
+    expect(result.topCategories).toContain("HR");
+  });
+});
+
+describe("buildZScoreMap", () => {
+  it("assigns z-score 0 to a team exactly at the mean", () => {
+    const teams = [
+      { teamId: 1, categories: { HR: 10 } },
+      { teamId: 2, categories: { HR: 20 } },
+      { teamId: 3, categories: { HR: 30 } },
+    ];
+    const averages = { HR: 20 };
+    const zMap = buildZScoreMap(teams, averages);
+    expect(zMap[2]["HR"]).toBeCloseTo(0, 5);
+  });
+
+  it("assigns positive z-score to team above mean on higher-is-better stat", () => {
+    const teams = [
+      { teamId: 1, categories: { HR: 10 } },
+      { teamId: 2, categories: { HR: 30 } },
+    ];
+    const averages = { HR: 20 };
+    const zMap = buildZScoreMap(teams, averages);
+    expect(zMap[2]["HR"]).toBeGreaterThan(0);
+    expect(zMap[1]["HR"]).toBeLessThan(0);
+  });
+
+  it("flips sign for lower-is-better stats (ERA): lower ERA = positive z-score", () => {
+    const teams = [
+      { teamId: 1, categories: { ERA: 2.0 } },
+      { teamId: 2, categories: { ERA: 5.0 } },
+    ];
+    const averages = { ERA: 3.5 };
+    const zMap = buildZScoreMap(teams, averages);
+    // team 1 has lower ERA = better, so positive z
+    expect(zMap[1]["ERA"]).toBeGreaterThan(0);
+    expect(zMap[2]["ERA"]).toBeLessThan(0);
+  });
+
+  it("treats missing category values as 0", () => {
+    const teams = [
+      { teamId: 1, categories: {} as Record<string, number> },
+      { teamId: 2, categories: { HR: 10 } as Record<string, number> },
+    ];
+    const averages = { HR: 5 };
+    const zMap = buildZScoreMap(teams, averages);
+    expect(Number.isFinite(zMap[1]["HR"])).toBe(true);
+  });
+
+  it("handles all teams with identical values (zero variance)", () => {
+    const teams = [
+      { teamId: 1, categories: { HR: 10 } },
+      { teamId: 2, categories: { HR: 10 } },
+    ];
+    const averages = { HR: 10 };
+    const zMap = buildZScoreMap(teams, averages);
+    expect(Number.isFinite(zMap[1]["HR"])).toBe(true);
+    expect(Number.isFinite(zMap[2]["HR"])).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #24

## Changes

- Added `buildZScoreMap` — computes per-category z-scores for all teams from season league data (sign-flipped for lower-is-better categories so positive z = better)
- Added `computeMatchupStrength(myZ, oppZ)` — returns mean of `(opp_z - my_z)` across all 16 categories, plus the top 2 driving categories by absolute differential
- Badge renders green (Favorable, score < -0.3), yellow (Even), or red (Tough, score > 0.3) next to each opponent on the schedule
- Tooltip on badge shows "Top factors: CAT1, CAT2" via `title` attribute
- Missing/null z-scores treated as 0 throughout
- Both exported functions are covered by 12 new Vitest tests in `web/src/tests/schedule.test.ts`