### PR TITLE
Rewrite eval/score.py for JS/TS scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ web/.vercel/
 web/out/
 web/coverage/
 web/*.tsbuildinfo
+
+# Remote Factory
+.factory/

--- a/eval/score.py
+++ b/eval/score.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Eval script for JS/TS Next.js project.
+
+Runs TypeScript type checking and observability analysis.
+
+Output format:
+    {"results": [{"name": str, "score": float, "weight": float, "passed": bool, "details": str}, ...]}
+"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def eval_syntax_check() -> dict:
+    """Run TypeScript compiler in noEmit mode to verify type safety."""
+    try:
+        result = subprocess.run(
+            ["npx", "tsc", "--noEmit"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            cwd="web",
+        )
+        passed = result.returncode == 0
+        if passed:
+            score = 1.0
+        else:
+            error_lines = [ln for ln in (result.stdout + result.stderr).splitlines() if ln.strip()]
+            if not error_lines:
+                score = 0.0
+            else:
+                score = max(0.0, 1.0 - len(error_lines) * 0.05)
+        return {
+            "name": "syntax_check",
+            "score": score,
+            "weight": 0.5,
+            "passed": passed,
+            "details": (result.stdout or result.stderr).strip()[-500:],
+        }
+    except subprocess.TimeoutExpired:
+        return {
+            "name": "syntax_check",
+            "score": 0.0,
+            "weight": 0.5,
+            "passed": False,
+            "details": "Timed out after 120s",
+        }
+
+
+def eval_observability() -> dict:
+    """Analyze observability coverage: logging, structured logging, request tracing."""
+    skip = {
+        "tests", "test", ".venv", "venv", "node_modules", "__pycache__",
+        ".git", ".factory", "eval", "dist", "build", ".mypy_cache", ".next",
+    }
+    log_pats = [
+        r"\blogger\.\w+\(",
+        r"\blogging\.\w+\(",
+        r"\blog\.\w+\(",
+        r"\bconsole\.\w+\(",
+    ]
+    struct_pats = [r"\bstructlog\b", r"\bpino\b", r"\bwinston\b",
+                   r"\bslog\.\w+\(", r"\btracing::"]
+    trace_pats = [r"request.id|req.id|trace.id", r"\bcontextvars\b|ContextVar",
+                  r"\bopentelemetry\b", r"trace.context|TraceContext|span"]
+
+    fn_pats = [
+        r"function\s+\w+",
+        r"const\s+\w+\s*=\s*(async\s+)?\(",
+        r"export\s+(default\s+)?(async\s+)?function",
+    ]
+
+    extensions = ("*.ts", "*.tsx", "*.js", "*.jsx")
+    sources = []
+    for ext in extensions:
+        sources.extend(
+            f for f in Path(".").rglob(ext)
+            if not any(p in f.parts for p in skip)
+        )
+
+    total_fn = logged_fn = total_log = 0
+    has_struct = has_trace = False
+
+    for src in sources:
+        try:
+            code = src.read_text(errors="replace")
+        except OSError:
+            continue
+
+        lines = code.splitlines()
+
+        fn_line_indices = []
+        for i, line in enumerate(lines):
+            for pat in fn_pats:
+                if re.search(pat, line):
+                    fn_line_indices.append(i)
+                    break
+
+        for fn_start in fn_line_indices:
+            total_fn += 1
+            end = min(fn_start + 50, len(lines))
+            body = "\n".join(lines[fn_start:end])
+            for pat in log_pats:
+                if re.search(pat, body):
+                    logged_fn += 1
+                    break
+
+        for pat in log_pats:
+            total_log += len(re.findall(pat, code))
+        for pat in struct_pats:
+            if re.search(pat, code):
+                has_struct = True
+        for pat in trace_pats:
+            if re.search(pat, code, re.IGNORECASE):
+                has_trace = True
+
+    if total_fn == 0:
+        return {"name": "observability", "score": 0.0, "weight": 0.5,
+                "passed": True, "details": "No functions found to analyze"}
+
+    cov = logged_fn / total_fn
+    density = min(1.0, total_log / max(total_fn, 1))
+    score = 0.40 * cov + 0.25 * float(has_struct) + 0.20 * float(has_trace) + 0.15 * density
+
+    details = (f"coverage={cov:.0%} ({logged_fn}/{total_fn}), "
+               f"structured={'yes' if has_struct else 'no'}, "
+               f"tracing={'yes' if has_trace else 'no'}, "
+               f"density={density:.0%}")
+
+    return {"name": "observability", "score": round(score, 3), "weight": 0.5,
+            "passed": score >= 0.3, "details": details}
+
+
+EVALS = [eval_syntax_check, eval_observability]
+
+
+def main() -> None:
+    results = [fn() for fn in EVALS]
+    output = {"results": results}
+    json.dump(output, sys.stdout, indent=2)
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/factory.md
+++ b/factory.md
@@ -1,0 +1,86 @@
+# Factory Configuration
+
+## Goal
+
+Improve the reliability, code quality, and test coverage of a Next.js 16 fantasy baseball "War Room" web app that fetches live data from ESPN APIs. The app suffers from edge case crashes (Infinity, NaN, null from ESPN), fragile data transformations, and zero test coverage.
+
+## Scope
+
+### Modifiable
+
+- web/src/**/*.ts
+- web/src/**/*.tsx
+- web/src/**/*.css
+- web/package.json
+- web/tsconfig.json
+- eval/**
+
+### Read-only
+
+- README.md
+- seasons/**
+- owners/**
+- analysis/**
+- output/**
+- data/**
+- scripts/**
+
+## Guards
+
+- Do not delete or overwrite existing page components
+- Do not modify files outside the declared scope
+- Do not introduce secrets or credentials into the repository
+- Do not change the ESPN league ID, team ID, or API endpoints
+- Do not remove existing error handling or data sanitization
+- Do not break the Vercel deployment (keep Next.js conventions)
+- Do not add mock data that could be confused with real ESPN data
+
+## Eval
+
+### Command
+
+```bash
+cd web && npx tsc --noEmit 2>&1 | tail -1 && npx next lint 2>&1 | tail -5
+```
+
+### Threshold
+
+0.7
+
+## Target Branch
+
+main
+
+## Project Eval
+
+### Dimensions
+
+- type_safety: TypeScript strict mode compliance, no `any` types, proper null checks
+- edge_case_handling: Sanitization for ESPN API edge cases (Infinity, NaN, null, division by zero, empty arrays)
+- test_coverage: Unit and integration test coverage for data transformations and API utilities
+- api_reliability: Proper error handling for ESPN API failures, timeouts, malformed responses
+
+## Eval Weights
+
+- hygiene: 40
+- growth: 20
+- project: 40
+
+## Hypothesis Budget
+
+- min_growth: 2
+- max_new: 3
+
+## Smoke Test
+
+```bash
+cd web && npx next build 2>&1 | tail -3
+```
+
+## Constraints
+
+- Prefer small, incremental changes over large rewrites
+- Each change should be accompanied by at least one test
+- Follow the existing code style (Next.js App Router, Tailwind CSS, TypeScript strict)
+- ESPN API data is unreliable: always sanitize numeric values before display
+- The app is deployed on Vercel: all API routes must work as serverless functions


### PR DESCRIPTION
Closes #26

## Changes
- Rewrote `eval_syntax_check()` to run `npx tsc --noEmit` instead of no-op `true`, providing real TypeScript type checking with partial scoring based on error count
- Rewrote `eval_observability()` to scan `.ts`, `.tsx`, `.js`, `.jsx` files using regex-based function detection (`function\s+\w+`, `const\s+\w+\s*=\s*(async\s+)?\(`, `export\s+(default\s+)?(async\s+)?function`)
- Updated skip list to include `node_modules`, `.next`, `dist`, `build`
- Kept existing `log_pats`, `struct_pats` (pino), and `trace_pats` arrays
- Set weights to 0.5 each (even split between syntax check and observability)
- Added `eval/**` to modifiable scope in `factory.md`

## Verification
```json
{
  "results": [
    {"name": "syntax_check", "score": 1.0, "weight": 0.5, "passed": true},
    {"name": "observability", "score": 0.542, "weight": 0.5, "passed": true}
  ]
}
```