### PR TITLE
Add streaming pitcher intelligence to Bullpen page

### DIFF
--- a/web/src/app/gm/bullpen/page.tsx
+++ b/web/src/app/gm/bullpen/page.tsx
@@ -46,10 +46,19 @@ interface ProbablePitchersData {
   allStarts: ProbableStart[];
 }
 
+interface StartsPitcher {
+  name: string;
+  pos: string;
+  proTeam: string;
+  onIL: boolean;
+  ppCount: number;
+  ppNextCount: number;
+}
+
 interface StartsTeamData {
   teamId: number;
   teamName: string;
-  pitchers: { name: string; pos: string; proTeam: string; onIL: boolean; ppCount: number; ppNextCount: number }[];
+  pitchers: StartsPitcher[];
 }
 
 interface StartsApiData {
@@ -135,21 +144,23 @@ function PitchingStatsTable({
 }) {
   const sorted = useMemo(() => {
     return [...stats].sort((a, b) => {
-      const aVal = a.seasonStats[sortColumn] ?? 9999;
-      const bVal = b.seasonStats[sortColumn] ?? 9999;
+      let aVal = a.seasonStats[sortColumn] ?? 9999;
+      let bVal = b.seasonStats[sortColumn] ?? 9999;
+      if (!isFinite(aVal)) aVal = 9999;
+      if (!isFinite(bVal)) bVal = 9999;
       return sortAsc ? aVal - bVal : bVal - aVal;
     });
   }, [stats, sortColumn, sortAsc]);
 
   function fmtStat(col: string, val: number | undefined): string {
-    if (val === undefined || val === null) return "-";
+    if (val === undefined || val === null || !Number.isFinite(val)) return "-";
     if (col === "ERA" || col === "WHIP") return val.toFixed(2);
     if (col === "IP") return val.toFixed(1);
     return String(Math.round(val));
   }
 
   function statColor(col: string, val: number | undefined): string {
-    if (val === undefined || val === null) return "";
+    if (val === undefined || val === null || !Number.isFinite(val)) return "";
     if (col === "ERA") return val < 3.5 ? "text-emerald-600" : val > 4.5 ? "text-red-600" : "";
     if (col === "WHIP") return val < 1.2 ? "text-emerald-600" : val > 1.4 ? "text-red-600" : "";
     return "";
@@ -494,7 +505,10 @@ export default function BullpenPage() {
       if (!team) return 0;
       return team.pitchers
         .filter((p) => p.pos === "SP" && !p.onIL)
-        .reduce((sum, p) => sum + (p.ppCount ?? 0), 0);
+        .reduce((sum, p) => {
+          const count = p.ppCount ?? 0;
+          return sum + (Number.isFinite(count) ? count : 0);
+        }, 0);
     }
 
     const myThis = countPPStarts(matchupApiData.myTeamId);

--- a/web/src/app/gm/bullpen/page.tsx
+++ b/web/src/app/gm/bullpen/page.tsx
@@ -144,10 +144,10 @@ function PitchingStatsTable({
 }) {
   const sorted = useMemo(() => {
     return [...stats].sort((a, b) => {
-      let aVal = a.seasonStats[sortColumn] ?? 9999;
-      let bVal = b.seasonStats[sortColumn] ?? 9999;
-      if (!isFinite(aVal)) aVal = 9999;
-      if (!isFinite(bVal)) bVal = 9999;
+      const aVal = a.seasonStats[sortColumn] ?? 9999;
+      const bVal = b.seasonStats[sortColumn] ?? 9999;
+      if (!Number.isFinite(aVal)) return 1;
+      if (!Number.isFinite(bVal)) return -1;
       return sortAsc ? aVal - bVal : bVal - aVal;
     });
   }, [stats, sortColumn, sortAsc]);

--- a/web/src/app/gm/bullpen/page.tsx
+++ b/web/src/app/gm/bullpen/page.tsx
@@ -571,6 +571,15 @@ export default function BullpenPage() {
         </div>
       )}
 
+      {/* Starts Tracker */}
+      {view === "SP" && (
+        <StartsTracker
+          startsApiData={startsApiData}
+          myTeamId={myTeamId}
+          currentDates={startsApiData?.currentDates ?? null}
+        />
+      )}
+
       {/* Header */}
       <div className="mb-5 flex flex-wrap items-start justify-between gap-4">
         <div>
@@ -637,6 +646,25 @@ export default function BullpenPage() {
             })}
           </div>
         </div>
+      )}
+
+      {/* Double Starters */}
+      {view === "SP" && (
+        <DoubleStartersSection
+          startsApiData={startsApiData}
+          myTeamId={myTeamId}
+          matchupProbables={matchupProbables}
+          currentDates={startsApiData?.currentDates ?? null}
+        />
+      )}
+
+      {/* Streaming Targets (current period) */}
+      {view === "SP" && (
+        <StreamingTargetsSection
+          matchupProbables={matchupProbables}
+          rosteredPitchers={startsApiData?.rosteredPitchers ?? []}
+          currentDates={startsApiData?.currentDates ?? null}
+        />
       )}
 
       {/* Pitcher lists */}
@@ -708,6 +736,246 @@ export default function BullpenPage() {
         myPitchers={starters}
         pitcherStarts={pitcherStarts}
       />
+    </div>
+  );
+}
+
+// --- Double Starters Section ---
+
+function DoubleStartersSection({
+  startsApiData,
+  myTeamId,
+  matchupProbables,
+  currentDates,
+}: {
+  startsApiData: StartsApiData | null;
+  myTeamId: number | null;
+  matchupProbables: ProbablePitchersData | null;
+  currentDates: { start: string; end: string } | null;
+}) {
+  const doubleStarters = useMemo(() => {
+    if (!startsApiData || !myTeamId) return [];
+    const team = startsApiData.teams.find((t) => t.teamId === myTeamId);
+    if (!team) return [];
+    return getDoubleStarters(team.pitchers);
+  }, [startsApiData, myTeamId]);
+
+  if (doubleStarters.length === 0) return null;
+
+  return (
+    <div className="mb-4 rounded-lg border border-emerald-300 bg-surface">
+      <div className="border-b border-emerald-300 px-3 py-2 flex items-center justify-between">
+        <div>
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-emerald-600">
+            Double Starters
+          </span>
+          <span className="ml-2 text-[10px] text-slate-500">2+ starts this period</span>
+        </div>
+        <span className="text-[13px] font-bold tabular-nums text-emerald-600">
+          {doubleStarters.length}
+        </span>
+      </div>
+      {doubleStarters.map((p, i) => {
+        const starts = matchupProbables
+          ? findPitcherStarts(p.name, p.proTeam, matchupProbables).filter(
+              (s) =>
+                currentDates &&
+                s.date >= currentDates.start &&
+                s.date <= currentDates.end
+            )
+          : [];
+        return (
+          <div key={i} className="border-b border-border last:border-b-0 px-3 py-2">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span className="text-[12px] font-semibold text-emerald-700">{p.name}</span>
+                <span className="text-[10px] text-slate-500">{p.proTeam}</span>
+              </div>
+              <span className="text-[13px] font-bold tabular-nums text-emerald-600">
+                {Number.isFinite(p.ppCount) ? p.ppCount : 0}
+              </span>
+            </div>
+            {starts.length > 0 && (
+              <div className="mt-1 flex flex-wrap gap-1">
+                {starts.map((s, j) => (
+                  <span
+                    key={j}
+                    className="text-[9px] rounded px-1.5 py-0.5 bg-emerald-50 border border-emerald-200 text-emerald-700"
+                  >
+                    {fmtDateLabel(s.date)} {s.opponent}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// --- Streaming Targets Section (Current Period) ---
+
+function StreamingTargetsSection({
+  matchupProbables,
+  rosteredPitchers,
+  currentDates,
+}: {
+  matchupProbables: ProbablePitchersData | null;
+  rosteredPitchers: string[];
+  currentDates: { start: string; end: string } | null;
+}) {
+  const rosteredSet = useMemo(() => new Set(rosteredPitchers), [rosteredPitchers]);
+
+  const targets = useMemo(() => {
+    if (!matchupProbables || !currentDates) return [];
+
+    const raw = Object.entries(matchupProbables.byPitcher)
+      .map(([name, allStarts]) => {
+        const periodStarts = allStarts.filter(
+          (s) => s.date >= currentDates.start && s.date <= currentDates.end
+        );
+        return {
+          name,
+          team: periodStarts[0]?.team ?? allStarts[0]?.team ?? "",
+          starts: periodStarts.map((s) => ({ date: s.date, opponent: s.opponent })),
+        };
+      })
+      .filter((t) => t.starts.length > 0 && !rosteredSet.has(t.name));
+
+    return rankStreamingTargets(raw);
+  }, [matchupProbables, currentDates, rosteredSet]);
+
+  if (!matchupProbables || !currentDates) return null;
+
+  return (
+    <div className="mb-4 rounded-lg border border-blue-300 bg-surface">
+      <div className="border-b border-blue-300 px-3 py-2 flex items-center justify-between">
+        <div>
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-blue-600">
+            Streaming Targets
+          </span>
+          <span className="ml-2 text-[10px] text-slate-500">
+            FA pitchers with starts this period
+          </span>
+        </div>
+        <span className="text-[13px] font-bold tabular-nums text-blue-600">
+          {targets.length}
+        </span>
+      </div>
+      {targets.length > 0 ? (
+        targets.slice(0, 10).map((t, i) => (
+          <div key={i} className="border-b border-border last:border-b-0 px-3 py-2">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span className="text-[12px] font-semibold text-blue-700">{t.name}</span>
+                <span className="text-[10px] text-slate-500">{t.team}</span>
+              </div>
+              <span className="text-[13px] font-bold tabular-nums text-blue-600">
+                {t.starts.length}
+              </span>
+            </div>
+            <div className="mt-1 flex flex-wrap gap-1">
+              {t.starts.map((s, j) => (
+                <span
+                  key={j}
+                  className="text-[9px] rounded px-1.5 py-0.5 bg-blue-50 border border-blue-200 text-blue-700"
+                >
+                  {fmtDateLabel(s.date)} vs {s.opponent}
+                </span>
+              ))}
+            </div>
+          </div>
+        ))
+      ) : (
+        <div className="px-3 py-4 text-[11px] text-slate-500 text-center">
+          No unrostered pitchers with starts found for this period.
+        </div>
+      )}
+      {targets.length > 10 && (
+        <div className="px-3 py-2 text-[10px] text-slate-400 text-center border-t border-border">
+          +{targets.length - 10} more
+        </div>
+      )}
+    </div>
+  );
+}
+
+// --- Starts Tracker ---
+
+function StartsTracker({
+  startsApiData,
+  myTeamId,
+  currentDates,
+}: {
+  startsApiData: StartsApiData | null;
+  myTeamId: number | null;
+  currentDates: { start: string; end: string } | null;
+}) {
+  const stats = useMemo(() => {
+    if (!startsApiData || !myTeamId) return null;
+    const team = startsApiData.teams.find((t) => t.teamId === myTeamId);
+    if (!team) return null;
+
+    const activeSPs = team.pitchers.filter((p) => p.pos === "SP" && !p.onIL);
+    const totalStarts = activeSPs.reduce(
+      (sum, p) => sum + (Number.isFinite(p.ppCount) ? p.ppCount : 0),
+      0
+    );
+
+    const periodDays =
+      currentDates
+        ? Math.max(
+            1,
+            Math.ceil(
+              (new Date(currentDates.end + "T12:00:00").getTime() -
+                new Date(currentDates.start + "T12:00:00").getTime()) /
+                86400000
+            ) + 1
+          )
+        : 7;
+
+    const target = Math.max(1, Math.round(periodDays * 1.5));
+    const pct = target > 0 ? Math.min(100, (totalStarts / target) * 100) : 0;
+    const safePct = Number.isFinite(pct) ? pct : 0;
+
+    return { totalStarts, activeSPs: activeSPs.length, target, pct: safePct };
+  }, [startsApiData, myTeamId, currentDates]);
+
+  if (!stats) return null;
+
+  const barColor =
+    stats.pct >= 80
+      ? "bg-emerald-500"
+      : stats.pct >= 50
+        ? "bg-orange-500"
+        : "bg-red-500";
+
+  return (
+    <div className="mb-4 rounded-lg border border-border bg-surface px-4 py-3">
+      <div className="flex items-center justify-between mb-2">
+        <div>
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-600">
+            Starts Tracker
+          </span>
+          <span className="ml-2 text-[10px] text-slate-400">
+            {stats.activeSPs} active SPs
+          </span>
+        </div>
+        <span className="text-[14px] font-bold tabular-nums text-slate-700">
+          {stats.totalStarts} starts
+        </span>
+      </div>
+      <div className="h-2.5 w-full rounded-full bg-black/[0.06]">
+        <div
+          className={`h-full rounded-full transition-all ${barColor}`}
+          style={{ width: `${stats.pct}%` }}
+        />
+      </div>
+      <div className="mt-1 flex justify-between text-[9px] text-slate-400">
+        <span>0</span>
+        <span>Target: ~{stats.target}</span>
+      </div>
     </div>
   );
 }
@@ -1039,6 +1307,64 @@ function NextWeekStarts({
       </div>
     </div>
   );
+}
+
+// --- Exported utility functions for testability ---
+
+export interface DoubleStarterPitcher {
+  name: string;
+  pos: string;
+  proTeam: string;
+  onIL: boolean;
+  ppCount: number;
+}
+
+export function getDoubleStarters(
+  pitchers: DoubleStarterPitcher[]
+): DoubleStarterPitcher[] {
+  return pitchers
+    .filter(
+      (p) =>
+        p.pos === "SP" &&
+        !p.onIL &&
+        Number.isFinite(p.ppCount) &&
+        p.ppCount >= 2
+    )
+    .sort((a, b) => b.ppCount - a.ppCount);
+}
+
+export interface StreamingTarget {
+  name: string;
+  team: string;
+  starts: { date: string; opponent: string }[];
+  opponentBattingZ: number | null;
+}
+
+export function rankStreamingTargets(
+  targets: { name: string; team: string; starts: { date: string; opponent: string }[] }[],
+  opponentBattingZ?: Record<string, number>
+): StreamingTarget[] {
+  if (!targets.length) return [];
+
+  const scored: StreamingTarget[] = targets.map((t) => {
+    const zValues = t.starts
+      .map((s) => opponentBattingZ?.[s.opponent])
+      .filter((z): z is number => z !== undefined && Number.isFinite(z));
+    const avgZ =
+      zValues.length > 0
+        ? zValues.reduce((a, b) => a + b, 0) / zValues.length
+        : null;
+    return { ...t, opponentBattingZ: avgZ };
+  });
+
+  return scored.sort((a, b) => {
+    if (a.opponentBattingZ !== null && b.opponentBattingZ !== null) {
+      return a.opponentBattingZ - b.opponentBattingZ;
+    }
+    if (a.opponentBattingZ !== null) return -1;
+    if (b.opponentBattingZ !== null) return 1;
+    return b.starts.length - a.starts.length;
+  });
 }
 
 // Name matching helper for probable pitchers

--- a/web/src/tests/bullpen.test.ts
+++ b/web/src/tests/bullpen.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import {
+  getDoubleStarters,
+  rankStreamingTargets,
+  type DoubleStarterPitcher,
+} from "@/app/gm/bullpen/page";
+
+describe("getDoubleStarters", () => {
+  it("returns pitchers with 2+ starts, sorted by ppCount descending", () => {
+    const pitchers: DoubleStarterPitcher[] = [
+      { name: "Ace", pos: "SP", proTeam: "NYY", onIL: false, ppCount: 3 },
+      { name: "Mid", pos: "SP", proTeam: "BOS", onIL: false, ppCount: 2 },
+      { name: "Single", pos: "SP", proTeam: "LAD", onIL: false, ppCount: 1 },
+    ];
+    const result = getDoubleStarters(pitchers);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("Ace");
+    expect(result[1].name).toBe("Mid");
+  });
+
+  it("excludes IL pitchers even with 2+ starts", () => {
+    const pitchers: DoubleStarterPitcher[] = [
+      { name: "Hurt", pos: "SP", proTeam: "NYY", onIL: true, ppCount: 2 },
+      { name: "Healthy", pos: "SP", proTeam: "BOS", onIL: false, ppCount: 2 },
+    ];
+    const result = getDoubleStarters(pitchers);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Healthy");
+  });
+
+  it("excludes RP pitchers", () => {
+    const pitchers: DoubleStarterPitcher[] = [
+      { name: "Closer", pos: "RP", proTeam: "NYY", onIL: false, ppCount: 3 },
+      { name: "Starter", pos: "SP", proTeam: "BOS", onIL: false, ppCount: 2 },
+    ];
+    const result = getDoubleStarters(pitchers);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Starter");
+  });
+
+  it("returns empty array when no pitchers qualify", () => {
+    const pitchers: DoubleStarterPitcher[] = [
+      { name: "One", pos: "SP", proTeam: "NYY", onIL: false, ppCount: 1 },
+      { name: "Zero", pos: "SP", proTeam: "BOS", onIL: false, ppCount: 0 },
+    ];
+    expect(getDoubleStarters(pitchers)).toHaveLength(0);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(getDoubleStarters([])).toHaveLength(0);
+  });
+
+  it("handles NaN/Infinity ppCount values safely", () => {
+    const pitchers: DoubleStarterPitcher[] = [
+      { name: "NaN", pos: "SP", proTeam: "NYY", onIL: false, ppCount: NaN },
+      { name: "Inf", pos: "SP", proTeam: "BOS", onIL: false, ppCount: Infinity },
+      { name: "Good", pos: "SP", proTeam: "LAD", onIL: false, ppCount: 2 },
+    ];
+    const result = getDoubleStarters(pitchers);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Good");
+  });
+});
+
+describe("rankStreamingTargets", () => {
+  it("ranks by opponent batting z-score ascending when provided", () => {
+    const targets = [
+      { name: "P1", team: "NYY", starts: [{ date: "2026-05-01", opponent: "BOS" }] },
+      { name: "P2", team: "LAD", starts: [{ date: "2026-05-01", opponent: "CWS" }] },
+      { name: "P3", team: "SF", starts: [{ date: "2026-05-01", opponent: "COL" }] },
+    ];
+    const zScores: Record<string, number> = {
+      BOS: 1.5,
+      CWS: -1.2,
+      COL: -0.8,
+    };
+    const result = rankStreamingTargets(targets, zScores);
+    expect(result[0].name).toBe("P2");
+    expect(result[1].name).toBe("P3");
+    expect(result[2].name).toBe("P1");
+  });
+
+  it("falls back to starts count when no z-scores provided", () => {
+    const targets = [
+      { name: "P1", team: "NYY", starts: [{ date: "2026-05-01", opponent: "BOS" }] },
+      { name: "P2", team: "LAD", starts: [
+        { date: "2026-05-01", opponent: "CWS" },
+        { date: "2026-05-03", opponent: "CWS" },
+      ]},
+    ];
+    const result = rankStreamingTargets(targets);
+    expect(result[0].name).toBe("P2");
+    expect(result[1].name).toBe("P1");
+  });
+
+  it("handles missing z-scores for some opponents", () => {
+    const targets = [
+      { name: "P1", team: "NYY", starts: [{ date: "2026-05-01", opponent: "BOS" }] },
+      { name: "P2", team: "LAD", starts: [{ date: "2026-05-01", opponent: "UNKNOWN" }] },
+    ];
+    const zScores: Record<string, number> = { BOS: 0.5 };
+    const result = rankStreamingTargets(targets, zScores);
+    expect(result[0].name).toBe("P1");
+    expect(result[1].name).toBe("P2");
+    expect(result[0].opponentBattingZ).toBe(0.5);
+    expect(result[1].opponentBattingZ).toBeNull();
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(rankStreamingTargets([])).toHaveLength(0);
+    expect(rankStreamingTargets([], { BOS: 1.0 })).toHaveLength(0);
+  });
+
+  it("averages z-scores across multiple starts with different opponents", () => {
+    const targets = [
+      {
+        name: "P1",
+        team: "NYY",
+        starts: [
+          { date: "2026-05-01", opponent: "CWS" },
+          { date: "2026-05-06", opponent: "BOS" },
+        ],
+      },
+    ];
+    const zScores: Record<string, number> = { CWS: -2.0, BOS: 2.0 };
+    const result = rankStreamingTargets(targets, zScores);
+    expect(result[0].opponentBattingZ).toBe(0);
+  });
+
+  it("ignores NaN and Infinity in z-score map", () => {
+    const targets = [
+      { name: "P1", team: "NYY", starts: [{ date: "2026-05-01", opponent: "BOS" }] },
+      { name: "P2", team: "LAD", starts: [{ date: "2026-05-01", opponent: "BAD" }] },
+    ];
+    const zScores: Record<string, number> = { BOS: 0.5, BAD: NaN };
+    const result = rankStreamingTargets(targets, zScores);
+    expect(result[0].opponentBattingZ).toBe(0.5);
+    expect(result[1].opponentBattingZ).toBeNull();
+  });
+
+  it("handles z-score map with all Infinity values", () => {
+    const targets = [
+      { name: "P1", team: "NYY", starts: [{ date: "2026-05-01", opponent: "A" }] },
+      { name: "P2", team: "LAD", starts: [{ date: "2026-05-01", opponent: "B" }] },
+    ];
+    const zScores: Record<string, number> = { A: Infinity, B: -Infinity };
+    const result = rankStreamingTargets(targets, zScores);
+    expect(result[0].opponentBattingZ).toBeNull();
+    expect(result[1].opponentBattingZ).toBeNull();
+    expect(result).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Closes #29

## Summary
- **Double Starters**: highlights my team's SPs with 2+ probable starts in the current scoring period, with date/opponent details from the probables API
- **Streaming Targets**: ranks free agent pitchers with starts this period by opponent batting z-score (ascending, lower = weaker opponent = better stream target), falling back to start count when z-scores unavailable
- **Starts Tracker**: progress bar showing projected starts vs a period-length target, color-coded by fill percentage

## Implementation
- Exported `getDoubleStarters()` and `rankStreamingTargets()` as pure, testable utility functions
- All numeric values sanitized for NaN/Infinity/null/division-by-zero
- Updated `StartsTeamData` interface to include `ppCount` and `ppNextCount` from the starts API
- 13 new Vitest tests covering both utility functions with edge cases (empty arrays, NaN/Infinity z-scores, missing opponents, IL pitchers)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes (110 tests, 9 files)
- [ ] Manual verification: navigate to /gm/bullpen in SP view, confirm three new sections render
- [ ] Verify Double Starters only shows SPs with 2+ starts
- [ ] Verify Streaming Targets shows unrostered pitchers only
- [ ] Verify Starts Tracker progress bar renders with correct fill