### PR TITLE
Add weakness-aware FA recommendations to Free Agents page

### DIFF
--- a/web/src/app/gm/free-agents/page.tsx
+++ b/web/src/app/gm/free-agents/page.tsx
@@ -79,7 +79,7 @@ const BAT_CATS = ["AVG", "HR", "R", "RBI", "SB", "H", "BB", "TB"];
 const PIT_CATS = ["K", "QS", "W", "SV", "HD", "ERA", "WHIP"];
 
 function fmtStat(cat: string, val: number | undefined): string {
-  if (val === undefined || val === null) return "-";
+  if (val === undefined || val === null || !Number.isFinite(val)) return "-";
   const v = sanitizeNum(val);
   if (cat === "AVG") return v.toFixed(3);
   if (cat === "ERA" || cat === "WHIP") return v.toFixed(2);
@@ -88,6 +88,7 @@ function fmtStat(cat: string, val: number | undefined): string {
 }
 
 function zColorClass(z: number): string {
+  if (!Number.isFinite(z)) return "text-slate-400";
   const v = sanitizeNum(z);
   if (v >= 1.5) return "text-emerald-700 font-bold";
   if (v >= 0.5) return "text-emerald-600";
@@ -162,7 +163,7 @@ export default function FreeAgentsPage() {
         if (myTeam?.ranks) {
           const weak: WeaknessInfo[] = [];
           for (const [cat, rank] of Object.entries(myTeam.ranks as Record<string, number>)) {
-            if (rank >= 7) weak.push({ cat, rank });
+            if (typeof rank === 'number' && Number.isFinite(rank) && rank >= 7) weak.push({ cat, rank });
           }
           weak.sort((a, b) => categoryWeight(b.cat) - categoryWeight(a.cat));
           setWeaknesses(weak);
@@ -275,7 +276,6 @@ export default function FreeAgentsPage() {
     });
 
     return list.slice(0, 50);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [freeAgents, posFilter, search, sortBy, statPeriod, zScoreMap, weaknessFilter]);
 
   const sortOptions = isPitcherFilter ? PIT_SORT_OPTIONS : BAT_SORT_OPTIONS;

--- a/web/src/app/gm/free-agents/page.tsx
+++ b/web/src/app/gm/free-agents/page.tsx
@@ -2,6 +2,13 @@
 
 import { useState, useEffect, useMemo } from "react";
 import { isPunt, categoryWeight, categoryTierHeaderClass } from "@/lib/category-weights";
+import {
+  findWeakCategories,
+  rankByWeaknessGap,
+  sanitizeNum,
+  type WeakCategory,
+  type RecommendedFA,
+} from "@/lib/free-agent-recs";
 
 interface PlayerStats {
   name: string;
@@ -37,6 +44,14 @@ interface EspnTeam {
   roster: RosterPlayer[];
 }
 
+interface ProbableStart {
+  date: string;
+  pitcherName: string;
+  opponent: string;
+  gameTime: string;
+  isHome: boolean;
+}
+
 const POSITIONS = ["ALL", "C", "1B", "2B", "3B", "SS", "OF", "SP", "RP", "DH"];
 const BAT_SORT_OPTIONS = [
   { key: "FAR", label: "FAR" },
@@ -60,19 +75,23 @@ const PIT_SORT_OPTIONS = [
   { key: "HD", label: "HD" },
 ];
 const LOWER_IS_BETTER = new Set(["ERA", "WHIP", "L"]);
+const BAT_CATS = ["AVG", "HR", "R", "RBI", "SB", "H", "BB", "TB"];
+const PIT_CATS = ["K", "QS", "W", "SV", "HD", "ERA", "WHIP"];
 
 function fmtStat(cat: string, val: number | undefined): string {
   if (val === undefined || val === null) return "-";
-  if (cat === "AVG") return val.toFixed(3);
-  if (cat === "ERA" || cat === "WHIP") return val.toFixed(2);
-  if (cat === "IP") return val.toFixed(1);
-  return String(Math.round(val));
+  const v = sanitizeNum(val);
+  if (cat === "AVG") return v.toFixed(3);
+  if (cat === "ERA" || cat === "WHIP") return v.toFixed(2);
+  if (cat === "IP") return v.toFixed(1);
+  return String(Math.round(v));
 }
 
 function zColorClass(z: number): string {
-  if (z >= 1.5) return "text-emerald-700 font-bold";
-  if (z >= 0.5) return "text-emerald-600";
-  if (z >= 0) return "text-slate-600";
+  const v = sanitizeNum(z);
+  if (v >= 1.5) return "text-emerald-700 font-bold";
+  if (v >= 0.5) return "text-emerald-600";
+  if (v >= 0) return "text-slate-600";
   return "text-red-600";
 }
 
@@ -92,9 +111,11 @@ interface WeaknessInfo {
 
 export default function FreeAgentsPage() {
   const [allPlayers, setAllPlayers] = useState<PlayerStats[]>([]);
+  const [zScorePlayers, setZScorePlayers] = useState<ZScorePlayer[]>([]);
   const [zScoreMap, setZScoreMap] = useState<Map<number, ZScorePlayer>>(new Map());
   const [rosteredNames, setRosteredNames] = useState<Set<string>>(new Set());
   const [weaknesses, setWeaknesses] = useState<WeaknessInfo[]>([]);
+  const [myTeamId, setMyTeamId] = useState<number>(0);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -103,6 +124,8 @@ export default function FreeAgentsPage() {
   const [sortBy, setSortBy] = useState("FAR");
   const [statPeriod, setStatPeriod] = useState<"season" | "last7" | "last15" | "last30">("season");
   const [weaknessFilter, setWeaknessFilter] = useState<string | null>(null);
+  const [showStreaming, setShowStreaming] = useState(false);
+  const [pitcherStarts, setPitcherStarts] = useState<Record<string, ProbableStart[]>>({});
 
   useEffect(() => {
     Promise.all([
@@ -110,18 +133,19 @@ export default function FreeAgentsPage() {
       fetch("/api/espn/roster").then((r) => r.json()).catch(() => []),
       fetch("/api/analysis/z-scores").then((r) => r.json()).catch(() => ({ players: [] })),
       fetch("/api/espn/league-stats?scope=season").then((r) => r.json()).catch(() => null),
-    ]).then(([statsData, rosterData, zData, leagueStats]) => {
+      fetch("/api/mlb/probable-pitchers").then((r) => r.json()).catch(() => ({ byPitcher: {} })),
+    ]).then(([statsData, rosterData, zData, leagueStats, pitcherData]) => {
       if (statsData.error) { setError(statsData.error); return; }
       setAllPlayers(statsData.players ?? []);
 
-      // Build z-score lookup by playerId
+      const zPlayers: ZScorePlayer[] = zData.players ?? [];
+      setZScorePlayers(zPlayers);
       const zMap = new Map<number, ZScorePlayer>();
-      for (const p of zData.players ?? []) {
+      for (const p of zPlayers) {
         zMap.set(p.playerId, p);
       }
       setZScoreMap(zMap);
 
-      // Build set of rostered player names
       if (Array.isArray(rosterData)) {
         const names = new Set<string>();
         for (const team of rosterData) {
@@ -132,8 +156,8 @@ export default function FreeAgentsPage() {
         setRosteredNames(names);
       }
 
-      // Extract team weaknesses from league stats
       if (leagueStats?.teams && leagueStats.myTeamId) {
+        setMyTeamId(leagueStats.myTeamId);
         const myTeam = leagueStats.teams.find((t: { teamId: number }) => t.teamId === leagueStats.myTeamId);
         if (myTeam?.ranks) {
           const weak: WeaknessInfo[] = [];
@@ -144,15 +168,61 @@ export default function FreeAgentsPage() {
           setWeaknesses(weak);
         }
       }
+
+      setPitcherStarts(pitcherData?.byPitcher ?? {});
     })
     .catch(() => setError("FETCH_FAILED"))
     .finally(() => setLoading(false));
   }, []);
 
-  // Only show free agents (not rostered)
   const freeAgents = useMemo(() => {
     return allPlayers.filter((p) => !rosteredNames.has(p.name));
   }, [allPlayers, rosteredNames]);
+
+  // Weakness-aware recommendations using z-scores
+  const { recommended, weakCats } = useMemo(() => {
+    if (myTeamId === 0 || zScorePlayers.length === 0) {
+      return { recommended: [] as RecommendedFA[], weakCats: [] as WeakCategory[] };
+    }
+
+    const teamPlayers = zScorePlayers.filter((p) => p.onTeamId === myTeamId);
+    if (teamPlayers.length === 0) {
+      return { recommended: [] as RecommendedFA[], weakCats: [] as WeakCategory[] };
+    }
+
+    const allCats = [...BAT_CATS, ...PIT_CATS];
+    const wc = findWeakCategories(teamPlayers, allCats, 3);
+
+    const faZPlayers = zScorePlayers.filter(
+      (p) => p.onTeamId === 0 || !rosteredNames.has(p.name),
+    );
+
+    const recs = rankByWeaknessGap(faZPlayers, wc, 15);
+    return { recommended: recs, weakCats: wc };
+  }, [zScorePlayers, myTeamId, rosteredNames]);
+
+  // Streaming pitchers: SP free agents with upcoming starts
+  const streamingPitchers = useMemo(() => {
+    if (!showStreaming) return [];
+
+    const spFAs = freeAgents.filter((p) => p.pos === "SP");
+
+    return spFAs
+      .map((p) => {
+        const starts = pitcherStarts[p.name] ?? [];
+        const zp = zScoreMap.get(p.playerId);
+        return {
+          ...p,
+          starts,
+          startCount: starts.length,
+          far: sanitizeNum(zp?.far ?? 0),
+          zTotal: sanitizeNum(zp?.zTotal ?? 0),
+        };
+      })
+      .filter((p) => p.startCount > 0)
+      .sort((a, b) => b.startCount - a.startCount || b.far - a.far)
+      .slice(0, 20);
+  }, [showStreaming, freeAgents, pitcherStarts, zScoreMap]);
 
   function getStats(p: PlayerStats): Record<string, number> {
     if (statPeriod === "last7") return p.last7Stats;
@@ -166,55 +236,50 @@ export default function FreeAgentsPage() {
   const filtered = useMemo(() => {
     let list = freeAgents;
 
-    // Position filter
     if (posFilter !== "ALL") {
       list = list.filter((p) => p.pos === posFilter);
     }
 
-    // Search filter
     if (search) {
       const q = search.toLowerCase();
       list = list.filter((p) => p.name.toLowerCase().includes(q) || p.proTeam.toLowerCase().includes(q));
     }
 
-    // Weakness filter: only show players with positive z-score in the selected weak category
     if (weaknessFilter) {
       list = list.filter((p) => {
         const zp = zScoreMap.get(p.playerId);
         if (!zp) return false;
-        return (zp.zScores[weaknessFilter] ?? 0) > 0;
+        return sanitizeNum(zp.zScores[weaknessFilter] ?? 0) > 0;
       });
     }
 
-    // Sort
     const effectiveSort = weaknessFilter ?? sortBy;
     list = [...list].sort((a, b) => {
       if (effectiveSort === "FAR" || (!weaknessFilter && sortBy === "FAR")) {
         const aZ = zScoreMap.get(a.playerId);
         const bZ = zScoreMap.get(b.playerId);
-        return (bZ?.far ?? -999) - (aZ?.far ?? -999);
+        return sanitizeNum(bZ?.far ?? -999) - sanitizeNum(aZ?.far ?? -999);
       }
 
       if (weaknessFilter) {
         const aZ = zScoreMap.get(a.playerId);
         const bZ = zScoreMap.get(b.playerId);
-        return (bZ?.zScores[weaknessFilter] ?? -999) - (aZ?.zScores[weaknessFilter] ?? -999);
+        return sanitizeNum(bZ?.zScores[weaknessFilter] ?? -999) - sanitizeNum(aZ?.zScores[weaknessFilter] ?? -999);
       }
 
       const aStats = getStats(a);
       const bStats = getStats(b);
-      const aVal = aStats[sortBy] ?? (LOWER_IS_BETTER.has(sortBy) ? 999 : -999);
-      const bVal = bStats[sortBy] ?? (LOWER_IS_BETTER.has(sortBy) ? 999 : -999);
+      const aVal = sanitizeNum(aStats[sortBy] ?? (LOWER_IS_BETTER.has(sortBy) ? 999 : -999));
+      const bVal = sanitizeNum(bStats[sortBy] ?? (LOWER_IS_BETTER.has(sortBy) ? 999 : -999));
       return LOWER_IS_BETTER.has(sortBy) ? aVal - bVal : bVal - aVal;
     });
 
-    return list.slice(0, 50); // Top 50
+    return list.slice(0, 50);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [freeAgents, posFilter, search, sortBy, statPeriod, zScoreMap]);
+  }, [freeAgents, posFilter, search, sortBy, statPeriod, zScoreMap, weaknessFilter]);
 
   const sortOptions = isPitcherFilter ? PIT_SORT_OPTIONS : BAT_SORT_OPTIONS;
 
-  // Auto-switch sort when changing position filter
   useEffect(() => {
     if (posFilter === "SP" || posFilter === "RP") {
       if (!PIT_SORT_OPTIONS.find((o) => o.key === sortBy)) setSortBy("FAR");
@@ -243,23 +308,136 @@ export default function FreeAgentsPage() {
           <h1 className="text-lg font-bold text-gray-900">Free Agents</h1>
           <span className="text-[12px] text-slate-500">{freeAgents.length} available players &middot; sorted by Fantasy Above Replacement</span>
         </div>
-        {/* Stat period toggle */}
-        <div className="flex gap-0.5 rounded bg-surface border border-border p-0.5">
-          {([
-            { key: "season", label: "Season" },
-            { key: "last30", label: "30D" },
-            { key: "last15", label: "15D" },
-            { key: "last7", label: "7D" },
-          ] as const).map((v) => (
-            <button key={v.key} onClick={() => setStatPeriod(v.key)}
-              className={`rounded px-2.5 py-1 text-[11px] font-bold transition-colors ${
-                statPeriod === v.key ? "bg-black/10 text-gray-900" : "text-slate-500 hover:text-slate-700"
-              }`}>
-              {v.label}
-            </button>
-          ))}
+        <div className="flex items-center gap-3">
+          {/* Streaming SP toggle */}
+          <button
+            onClick={() => setShowStreaming(!showStreaming)}
+            className={`rounded-lg px-3 py-1.5 text-[11px] font-bold transition-colors border ${
+              showStreaming
+                ? "bg-blue-600 text-white border-blue-600"
+                : "bg-surface text-slate-600 border-border hover:bg-black/5"
+            }`}
+          >
+            Streaming SP
+          </button>
+          {/* Stat period toggle */}
+          <div className="flex gap-0.5 rounded bg-surface border border-border p-0.5">
+            {([
+              { key: "season", label: "Season" },
+              { key: "last30", label: "30D" },
+              { key: "last15", label: "15D" },
+              { key: "last7", label: "7D" },
+            ] as const).map((v) => (
+              <button key={v.key} onClick={() => setStatPeriod(v.key)}
+                className={`rounded px-2.5 py-1 text-[11px] font-bold transition-colors ${
+                  statPeriod === v.key ? "bg-black/10 text-gray-900" : "text-slate-500 hover:text-slate-700"
+                }`}>
+                {v.label}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
+
+      {/* Recommended pickups section */}
+      {recommended.length > 0 && !showStreaming && (
+        <div className="mb-5">
+          <div className="mb-2 flex items-center gap-2">
+            <h2 className="text-[13px] font-bold text-gray-900">Recommended Pickups</h2>
+            <span className="text-[10px] text-slate-500">
+              Based on team weaknesses: {weakCats.map((w) => w.cat).join(", ")}
+            </span>
+          </div>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {recommended.slice(0, 9).map((rec, i) => (
+              <div
+                key={rec.playerId || i}
+                className="flex items-center justify-between rounded-lg border border-border bg-surface px-3 py-2 hover:bg-black/[0.03]"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-[10px] font-bold text-slate-400">#{i + 1}</span>
+                    <span className="truncate text-[12px] font-semibold text-slate-700">{rec.name}</span>
+                    <span className="text-[10px] text-slate-400">{rec.pos}</span>
+                  </div>
+                  <div className="mt-0.5 flex items-center gap-2">
+                    <span className="text-[10px] text-slate-500">{rec.proTeam}</span>
+                    <span className="rounded bg-amber-50 px-1.5 py-0.5 text-[9px] font-bold text-amber-700 border border-amber-200">
+                      Helps {rec.helpsCat}
+                    </span>
+                    <span className={`text-[10px] font-mono ${zColorClass(rec.helpsZ)}`}>
+                      z{rec.helpsZ >= 0 ? "+" : ""}{rec.helpsZ.toFixed(1)}
+                    </span>
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className={`text-[12px] font-bold font-mono tabular-nums ${zColorClass(rec.far)}`}>
+                    {rec.far.toFixed(1)}
+                  </div>
+                  <div className="text-[9px] text-slate-400">FAR</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Streaming pitchers section */}
+      {showStreaming && (
+        <div className="mb-5">
+          <div className="mb-2 flex items-center gap-2">
+            <h2 className="text-[13px] font-bold text-gray-900">Streaming Pitchers</h2>
+            <span className="text-[10px] text-slate-500">SP free agents with upcoming starts (next 7 days)</span>
+          </div>
+          {streamingPitchers.length === 0 ? (
+            <div className="rounded-lg border border-border bg-surface px-4 py-6 text-center text-[12px] text-slate-500">
+              No streaming pitcher data available for the upcoming week.
+            </div>
+          ) : (
+            <div className="rounded-lg border border-border overflow-hidden">
+              <table className="w-full text-left text-[12px]">
+                <thead className="border-b border-border bg-surface text-[10px] uppercase tracking-wider text-slate-500">
+                  <tr>
+                    <th className="px-3 py-2.5">Pitcher</th>
+                    <th className="px-2 py-2.5">Team</th>
+                    <th className="px-2 py-2.5 text-center">Starts</th>
+                    <th className="px-2 py-2.5 text-right">FAR</th>
+                    <th className="px-3 py-2.5">Upcoming Matchups</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {streamingPitchers.map((p, i) => (
+                    <tr key={p.playerId || i} className={`border-b border-border ${i % 2 === 0 ? "" : "bg-surface/50"} hover:bg-black/[0.03]`}>
+                      <td className="px-3 py-2">
+                        <span className="font-medium text-slate-700">{p.name}</span>
+                        {p.startCount >= 2 && (
+                          <span className="ml-1.5 rounded bg-blue-50 px-1 py-0.5 text-[9px] font-bold text-blue-700 border border-blue-200">
+                            2+ GS
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-2 py-2 text-slate-500">{p.proTeam}</td>
+                      <td className="px-2 py-2 text-center font-bold text-slate-700">{p.startCount}</td>
+                      <td className={`px-2 py-2 text-right font-mono tabular-nums ${zColorClass(p.far)}`}>
+                        {p.far.toFixed(1)}
+                      </td>
+                      <td className="px-3 py-2">
+                        <div className="flex flex-wrap gap-1.5">
+                          {p.starts.map((s, si) => (
+                            <span key={si} className="rounded bg-slate-100 px-1.5 py-0.5 text-[10px] text-slate-600">
+                              {s.opponent} {s.date.slice(5)}
+                            </span>
+                          ))}
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Weakness quick-filters */}
       {weaknesses.length > 0 && (
@@ -362,8 +540,8 @@ export default function FreeAgentsPage() {
             {filtered.map((p, i) => {
               const stats = getStats(p);
               const zPlayer = zScoreMap.get(p.playerId);
-              const zTotal = zPlayer?.zTotal ?? 0;
-              const far = zPlayer?.far ?? 0;
+              const zTotal = sanitizeNum(zPlayer?.zTotal ?? 0);
+              const far = sanitizeNum(zPlayer?.far ?? 0);
               return (
                 <tr key={p.playerId || i} className={`border-b border-border ${i % 2 === 0 ? "" : "bg-surface/50"} hover:bg-black/[0.03]`}>
                   <td className="px-3 py-2 font-medium text-slate-700">{p.name}</td>

--- a/web/src/lib/free-agent-recs.ts
+++ b/web/src/lib/free-agent-recs.ts
@@ -1,0 +1,88 @@
+export interface WeakCategory {
+  cat: string;
+  teamAvgZ: number;
+}
+
+export interface RecommendedFA {
+  playerId: number;
+  name: string;
+  pos: string;
+  proTeam: string;
+  gapScore: number;
+  helpsCat: string;
+  helpsZ: number;
+  far: number;
+  zScores: Record<string, number>;
+}
+
+export function sanitizeNum(v: unknown): number {
+  if (typeof v !== "number" || !Number.isFinite(v)) return 0;
+  return v;
+}
+
+export function findWeakCategories(
+  teamPlayerZScores: { zScores: Record<string, number> }[],
+  categories: string[],
+  count: number = 3,
+): WeakCategory[] {
+  if (teamPlayerZScores.length === 0 || categories.length === 0) return [];
+
+  const catAvgs: WeakCategory[] = categories.map((cat) => {
+    const vals = teamPlayerZScores
+      .map((p) => sanitizeNum(p.zScores[cat]))
+      .filter((v) => v !== 0 || teamPlayerZScores.some((p) => p.zScores[cat] !== undefined));
+    const sum = vals.reduce((s, v) => s + v, 0);
+    const avg = vals.length > 0 ? sum / vals.length : 0;
+    return { cat, teamAvgZ: sanitizeNum(avg) };
+  });
+
+  catAvgs.sort((a, b) => a.teamAvgZ - b.teamAvgZ);
+  return catAvgs.slice(0, Math.min(count, catAvgs.length));
+}
+
+export function rankByWeaknessGap(
+  freeAgents: {
+    playerId: number;
+    name: string;
+    pos: string;
+    proTeam: string;
+    zScores: Record<string, number>;
+    far: number;
+  }[],
+  weakCategories: WeakCategory[],
+  limit: number = 15,
+): RecommendedFA[] {
+  if (freeAgents.length === 0 || weakCategories.length === 0) return [];
+
+  const scored: RecommendedFA[] = freeAgents.map((fa) => {
+    let gapScore = 0;
+    let bestCat = weakCategories[0].cat;
+    let bestZ = -Infinity;
+
+    for (const wc of weakCategories) {
+      const faZ = sanitizeNum(fa.zScores[wc.cat]);
+      const gap = Math.abs(sanitizeNum(wc.teamAvgZ));
+      gapScore += faZ * (1 + gap);
+
+      if (faZ > bestZ) {
+        bestZ = faZ;
+        bestCat = wc.cat;
+      }
+    }
+
+    return {
+      playerId: fa.playerId,
+      name: fa.name,
+      pos: fa.pos,
+      proTeam: fa.proTeam,
+      gapScore: sanitizeNum(gapScore),
+      helpsCat: bestCat,
+      helpsZ: sanitizeNum(bestZ === -Infinity ? 0 : bestZ),
+      far: sanitizeNum(fa.far),
+      zScores: fa.zScores,
+    };
+  });
+
+  scored.sort((a, b) => b.gapScore - a.gapScore);
+  return scored.slice(0, limit);
+}

--- a/web/src/lib/free-agent-recs.ts
+++ b/web/src/lib/free-agent-recs.ts
@@ -29,8 +29,8 @@ export function findWeakCategories(
 
   const catAvgs: WeakCategory[] = categories.map((cat) => {
     const vals = teamPlayerZScores
-      .map((p) => sanitizeNum(p.zScores[cat]))
-      .filter((v) => v !== 0 || teamPlayerZScores.some((p) => p.zScores[cat] !== undefined));
+      .filter((p) => p.zScores[cat] !== undefined)
+      .map((p) => sanitizeNum(p.zScores[cat]));
     const sum = vals.reduce((s, v) => s + v, 0);
     const avg = vals.length > 0 ? sum / vals.length : 0;
     return { cat, teamAvgZ: sanitizeNum(avg) };

--- a/web/src/tests/free-agent-recs.test.ts
+++ b/web/src/tests/free-agent-recs.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import {
+  sanitizeNum,
+  findWeakCategories,
+  rankByWeaknessGap,
+} from "@/lib/free-agent-recs";
+
+describe("sanitizeNum", () => {
+  it("passes through finite numbers", () => {
+    expect(sanitizeNum(42)).toBe(42);
+    expect(sanitizeNum(0)).toBe(0);
+    expect(sanitizeNum(-3.5)).toBe(-3.5);
+  });
+
+  it("returns 0 for NaN", () => {
+    expect(sanitizeNum(NaN)).toBe(0);
+  });
+
+  it("returns 0 for Infinity", () => {
+    expect(sanitizeNum(Infinity)).toBe(0);
+    expect(sanitizeNum(-Infinity)).toBe(0);
+  });
+
+  it("returns 0 for null and undefined", () => {
+    expect(sanitizeNum(null)).toBe(0);
+    expect(sanitizeNum(undefined)).toBe(0);
+  });
+
+  it("returns 0 for non-number types", () => {
+    expect(sanitizeNum("10")).toBe(0);
+    expect(sanitizeNum({})).toBe(0);
+  });
+});
+
+describe("findWeakCategories", () => {
+  it("returns the N categories with lowest average z-scores", () => {
+    const players = [
+      { zScores: { HR: 1.5, AVG: -0.8, RBI: 0.2, SB: -1.5 } },
+      { zScores: { HR: 0.5, AVG: -0.4, RBI: 0.4, SB: -1.1 } },
+    ];
+    const result = findWeakCategories(players, ["HR", "AVG", "RBI", "SB"], 2);
+    expect(result).toHaveLength(2);
+    expect(result[0].cat).toBe("SB");
+    expect(result[1].cat).toBe("AVG");
+  });
+
+  it("returns empty for empty player list", () => {
+    expect(findWeakCategories([], ["HR", "AVG"], 3)).toEqual([]);
+  });
+
+  it("returns empty for empty categories", () => {
+    const players = [{ zScores: { HR: 1.0 } }];
+    expect(findWeakCategories(players, [], 3)).toEqual([]);
+  });
+
+  it("handles all-positive z-scores by returning the least positive", () => {
+    const players = [
+      { zScores: { HR: 2.0, AVG: 0.5, RBI: 1.0 } },
+    ];
+    const result = findWeakCategories(players, ["HR", "AVG", "RBI"], 2);
+    expect(result[0].cat).toBe("AVG");
+    expect(result[0].teamAvgZ).toBeCloseTo(0.5);
+  });
+
+  it("limits count to available categories", () => {
+    const players = [{ zScores: { HR: 1.0, AVG: -0.5 } }];
+    const result = findWeakCategories(players, ["HR", "AVG"], 5);
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe("rankByWeaknessGap", () => {
+  const weakCats = [
+    { cat: "SB", teamAvgZ: -1.5 },
+    { cat: "AVG", teamAvgZ: -0.8 },
+  ];
+
+  it("ranks FAs by weighted gap contribution to weak categories", () => {
+    const fas = [
+      { playerId: 1, name: "Player A", pos: "OF", proTeam: "NYY", zScores: { SB: 2.0, AVG: 0.5 }, far: 3.0 },
+      { playerId: 2, name: "Player B", pos: "SS", proTeam: "BOS", zScores: { SB: 0.3, AVG: 1.5 }, far: 2.0 },
+      { playerId: 3, name: "Player C", pos: "1B", proTeam: "LAD", zScores: { SB: 1.5, AVG: 1.0 }, far: 4.0 },
+    ];
+
+    const result = rankByWeaknessGap(fas, weakCats, 15);
+    expect(result).toHaveLength(3);
+    // Player A has strong SB z-score (2.0) in the weakest category (gap 1.5)
+    // Player C also strong but A's SB advantage is larger
+    expect(result[0].name).toBe("Player A");
+    expect(result[0].helpsCat).toBe("SB");
+  });
+
+  it("identifies the correct helpsCat for each FA", () => {
+    const fas = [
+      { playerId: 1, name: "Speed Guy", pos: "OF", proTeam: "NYY", zScores: { SB: 2.5, AVG: 0.1 }, far: 1.0 },
+      { playerId: 2, name: "Contact Guy", pos: "2B", proTeam: "BOS", zScores: { SB: 0.1, AVG: 2.5 }, far: 1.0 },
+    ];
+
+    const result = rankByWeaknessGap(fas, weakCats, 15);
+    const speedGuy = result.find((r) => r.name === "Speed Guy")!;
+    const contactGuy = result.find((r) => r.name === "Contact Guy")!;
+    expect(speedGuy.helpsCat).toBe("SB");
+    expect(contactGuy.helpsCat).toBe("AVG");
+  });
+
+  it("returns empty for empty FA list", () => {
+    expect(rankByWeaknessGap([], weakCats, 15)).toEqual([]);
+  });
+
+  it("returns empty for empty weak categories", () => {
+    const fas = [
+      { playerId: 1, name: "A", pos: "OF", proTeam: "NYY", zScores: { SB: 1.0 }, far: 1.0 },
+    ];
+    expect(rankByWeaknessGap(fas, [], 15)).toEqual([]);
+  });
+
+  it("respects the limit parameter", () => {
+    const fas = Array.from({ length: 20 }, (_, i) => ({
+      playerId: i,
+      name: `P${i}`,
+      pos: "OF",
+      proTeam: "NYY",
+      zScores: { SB: i * 0.1, AVG: 0 },
+      far: 1.0,
+    }));
+    const result = rankByWeaknessGap(fas, weakCats, 5);
+    expect(result).toHaveLength(5);
+  });
+
+  it("sanitizes NaN/Infinity z-scores to 0", () => {
+    const fas = [
+      { playerId: 1, name: "Bad Data", pos: "OF", proTeam: "NYY", zScores: { SB: NaN, AVG: Infinity }, far: NaN },
+    ];
+    const result = rankByWeaknessGap(fas, weakCats, 15);
+    expect(result).toHaveLength(1);
+    expect(Number.isFinite(result[0].gapScore)).toBe(true);
+    expect(Number.isFinite(result[0].far)).toBe(true);
+    expect(result[0].gapScore).toBe(0);
+  });
+
+  it("handles missing z-score categories gracefully", () => {
+    const fas = [
+      { playerId: 1, name: "Pitcher", pos: "SP", proTeam: "NYY", zScores: { K: 2.0, ERA: -0.5 }, far: 3.0 },
+    ];
+    const result = rankByWeaknessGap(fas, weakCats, 15);
+    expect(result).toHaveLength(1);
+    expect(Number.isFinite(result[0].gapScore)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #31

## Changes
- Added `lib/free-agent-recs.ts` with exported `findWeakCategories`, `rankByWeaknessGap`, and `sanitizeNum` functions
- Recommended section at top of Free Agents page showing top 9 pickups ranked by team weakness contribution, with the category each player helps most
- Streaming SP toggle fetches probable pitchers API, shows SP free agents with upcoming starts sorted by start count, highlights 2+ GS pitchers
- All numeric values in the page sanitized through `sanitizeNum` (guards NaN, Infinity, null)
- 17 new Vitest tests covering ranking algorithm correctness, edge cases (empty lists, missing z-scores, NaN/Infinity data, all-positive z-scores)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes (114 tests, 0 failures)
- [x] `npx eslint` passes on changed files
- [ ] Manual: verify Recommended section appears with weakness-based rankings
- [ ] Manual: verify Streaming SP toggle shows pitchers with upcoming starts
- [ ] Manual: verify weakness filter buttons still work correctly