### PR TITLE
Add surplus detection and gap analysis to Trade Room

### DIFF
--- a/web/src/app/api/analysis/z-scores/route.ts
+++ b/web/src/app/api/analysis/z-scores/route.ts
@@ -189,6 +189,10 @@ export async function GET(req: Request) {
             continue;
           }
           const { mu, sd } = catStats[cat];
+          if (sd === 0) {
+            zScores[cat] = 0;
+            continue;
+          }
           let z = (val - mu) / sd;
 
           // Invert for categories where lower is better

--- a/web/src/app/api/analysis/z-scores/route.ts
+++ b/web/src/app/api/analysis/z-scores/route.ts
@@ -44,6 +44,7 @@ export interface ZScorePlayer {
   zScores: Record<string, number>;
   zTotal: number;
   far: number;
+  espnRank: number;
 }
 
 export async function GET(req: Request) {
@@ -107,11 +108,13 @@ export async function GET(req: Request) {
       isPitcher: boolean;
       onTeamId: number;
       seasonStats: Record<string, number>;
+      espnRank: number;
     }
 
     const batters: RawPlayer[] = [];
     const pitchers: RawPlayer[] = [];
 
+    let espnIdx = 0;
     for (const entry of data.players ?? []) {
       const player = entry.player ?? {};
       const name: string = player.fullName ?? "";
@@ -134,6 +137,7 @@ export async function GET(req: Request) {
         if (cat) seasonStats[cat] = val as number;
       }
 
+      espnIdx++;
       const raw: RawPlayer = {
         name,
         playerId: player.id ?? 0,
@@ -142,6 +146,7 @@ export async function GET(req: Request) {
         isPitcher,
         onTeamId: entry.onTeamId ?? 0,
         seasonStats,
+        espnRank: espnIdx,
       };
 
       if (isPitcher) {
@@ -214,6 +219,7 @@ export async function GET(req: Request) {
           zScores,
           zTotal,
           far,
+          espnRank: p.espnRank,
         };
       });
     }

--- a/web/src/app/gm/trade/page.tsx
+++ b/web/src/app/gm/trade/page.tsx
@@ -290,8 +290,8 @@ export default function TradeRoomPage() {
     const impact: Record<string, { sending: number; receiving: number; net: number }> = {};
 
     for (const cat of ALL_CATS) {
-      const sendTotal = sending.reduce((sum, name) => sum + (getStats(name)[cat] ?? 0), 0);
-      const recvTotal = receiving.reduce((sum, name) => sum + (getStats(name)[cat] ?? 0), 0);
+      const sendTotal = sending.reduce((sum, name) => { const v = getStats(name)[cat] ?? 0; return sum + (Number.isFinite(v) ? v : 0); }, 0);
+      const recvTotal = receiving.reduce((sum, name) => { const v = getStats(name)[cat] ?? 0; return sum + (Number.isFinite(v) ? v : 0); }, 0);
       impact[cat] = { sending: sendTotal, receiving: recvTotal, net: recvTotal - sendTotal };
     }
 
@@ -301,8 +301,8 @@ export default function TradeRoomPage() {
 
   // Z-score trade impact
   const zTradeImpact = useMemo(() => {
-    const sendFar = sending.reduce((sum, name) => sum + (zScoreByName.get(name)?.far ?? 0), 0);
-    const recvFar = receiving.reduce((sum, name) => sum + (zScoreByName.get(name)?.far ?? 0), 0);
+    const sendFar = sending.reduce((sum, name) => { const v = zScoreByName.get(name)?.far ?? 0; return sum + (Number.isFinite(v) ? v : 0); }, 0);
+    const recvFar = receiving.reduce((sum, name) => { const v = zScoreByName.get(name)?.far ?? 0; return sum + (Number.isFinite(v) ? v : 0); }, 0);
     return { sendFar, recvFar, netFar: recvFar - sendFar };
   }, [sending, receiving, zScoreByName]);
 

--- a/web/src/app/gm/trade/page.tsx
+++ b/web/src/app/gm/trade/page.tsx
@@ -1,6 +1,18 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import {
+  findSurplusCategories,
+  computeGapAnalysis,
+  findSellHighCandidates,
+  findMetricArbitrage,
+  safeNum,
+  type SurplusCategory,
+  type GapPartner,
+  type SellHighCandidate,
+  type ArbitrageCandidate,
+  type PlayerStats as TradePlayerStats,
+} from "@/lib/trade-analysis";
 
 interface RosterPlayer {
   name: string;
@@ -40,6 +52,7 @@ interface ZScorePlayer {
   zScores: Record<string, number>;
   zTotal: number;
   far: number;
+  espnRank?: number;
 }
 
 interface StandingsTeam {
@@ -293,34 +306,45 @@ export default function TradeRoomPage() {
     return { sendFar, recvFar, netFar: recvFar - sendFar };
   }, [sending, receiving, zScoreByName]);
 
-  // Sell-high candidates: my players performing above their projected level
-  // Identify players with high recent stats (last 7/15) relative to season
-  const sellHighCandidates = useMemo(() => {
-    if (!myTeam) return [];
-    const candidates: { name: string; pos: string; reason: string; far: number }[] = [];
-    for (const p of myTeam.roster) {
-      const ps = statsMap.get(p.name);
-      const zp = zScoreByName.get(p.name);
-      if (!ps || !zp) continue;
-      const isPitcher = p.pos === "SP" || p.pos === "RP";
+  // Surplus Detector: categories where my team ranks top-3 in the league
+  const surplusCategories = useMemo((): SurplusCategory[] => {
+    if (!myTeam || !zScorePlayers.length) return [];
+    return findSurplusCategories(zScorePlayers, ALL_CATS, myTeam.id, teamNameMap);
+  }, [myTeam, zScorePlayers, teamNameMap]);
 
-      // Sell high if last 7 day stats are significantly better than season
-      if (!isPitcher) {
-        const seasonAvg = ps.seasonStats.AVG ?? 0;
-        const recent = ps.last7Stats.AVG ?? 0;
-        if (recent > seasonAvg + 0.050 && seasonAvg > 0 && recent > 0.300) {
-          candidates.push({ name: p.name, pos: p.pos, reason: `.${(recent * 1000).toFixed(0)} last 7D vs .${(seasonAvg * 1000).toFixed(0)} season`, far: zp.far });
-        }
-      } else {
-        const seasonEra = ps.seasonStats.ERA ?? 99;
-        const recent = ps.last7Stats.ERA ?? 99;
-        if (recent < seasonEra - 1.5 && recent < 3.0 && seasonEra > 0) {
-          candidates.push({ name: p.name, pos: p.pos, reason: `${recent.toFixed(2)} ERA last 7D vs ${seasonEra.toFixed(2)} season`, far: zp.far });
-        }
-      }
+  // Gap Analysis: per-opponent category differentials for trade matching
+  const gapPartners = useMemo((): GapPartner[] => {
+    if (!myTeam || !zScorePlayers.length) return [];
+    return computeGapAnalysis(zScorePlayers, ALL_CATS, myTeam.id, teamNameMap);
+  }, [myTeam, zScorePlayers, teamNameMap]);
+
+  // Sell-High Candidates: players whose 30-day z-scores exceed season z-scores by >0.5 SD
+  const sellHighCandidates = useMemo((): SellHighCandidate[] => {
+    if (!myTeam || !zScorePlayers.length) return [];
+    const tradeStatsMap = new Map<string, TradePlayerStats>();
+    for (const ps of playerStats) {
+      tradeStatsMap.set(ps.name, {
+        name: ps.name,
+        pos: ps.pos,
+        seasonStats: ps.seasonStats,
+        last30Stats: ps.last30Stats,
+      });
     }
-    return candidates.sort((a, b) => b.far - a.far);
-  }, [myTeam, statsMap, zScoreByName]);
+    return findSellHighCandidates(
+      myTeam.roster.map((p) => ({ name: p.name, pos: p.pos })),
+      zScorePlayers,
+      tradeStatsMap,
+      myTeam.id,
+      BAT_CATS,
+      PIT_CATS,
+    );
+  }, [myTeam, zScorePlayers, playerStats]);
+
+  // Metric Arbitrage: players where z-score rank differs from ESPN default rank
+  const arbitrageCandidates = useMemo((): ArbitrageCandidate[] => {
+    if (!myTeam || !zScorePlayers.length) return [];
+    return findMetricArbitrage(zScorePlayers, myTeam.id, teamNameMap);
+  }, [myTeam, zScorePlayers, teamNameMap]);
 
   // Position surplus: positions where we have 2+ starters
   const positionSurplus = useMemo(() => {
@@ -434,34 +458,124 @@ export default function TradeRoomPage() {
         </div>
       </div>
 
-      {/* Sell High + Position Surplus */}
-      {(sellHighCandidates.length > 0 || positionSurplus.length > 0) && (
+      {/* Surplus Detector + Sell-High Candidates */}
+      {(surplusCategories.length > 0 || sellHighCandidates.length > 0) && (
         <div className="mb-4 grid gap-4 sm:grid-cols-2">
+          {surplusCategories.length > 0 && (
+            <div className="rounded-lg border border-teal-300 bg-teal-50/50 px-4 py-3">
+              <div className="text-[10px] font-semibold uppercase tracking-wider text-teal-700 mb-2">Category Surplus (Top 3)</div>
+              {surplusCategories.map((s) => (
+                <div key={s.cat} className="py-1.5 border-b border-teal-200/50 last:border-0">
+                  <div className="flex items-center justify-between">
+                    <span className="text-[12px] font-bold text-teal-700">{s.cat} <span className="text-[10px] font-normal text-teal-600">#{s.rank}</span></span>
+                    <span className="text-[10px] text-slate-400">Trade chips:</span>
+                  </div>
+                  <div className="mt-0.5 flex flex-wrap gap-1">
+                    {s.players.map((p) => (
+                      <span key={p.name} className="text-[10px] text-slate-600">
+                        {p.name} <span className="text-teal-600">(+{safeNum(p.zScore).toFixed(1)})</span>
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
           {sellHighCandidates.length > 0 && (
             <div className="rounded-lg border border-purple-300 bg-purple-50/50 px-4 py-3">
-              <div className="text-[10px] font-semibold uppercase tracking-wider text-purple-700 mb-2">Sell High</div>
-              {sellHighCandidates.map((c, i) => (
-                <div key={i} className="flex items-center justify-between py-1 border-b border-purple-200/50 last:border-0">
-                  <div>
-                    <span className="text-[12px] font-medium text-slate-700">{c.name}</span>
-                    <span className="text-[10px] text-slate-500 ml-1">{c.pos}</span>
+              <div className="text-[10px] font-semibold uppercase tracking-wider text-purple-700 mb-2">Sell High (30D z vs Season z)</div>
+              {sellHighCandidates.map((c) => (
+                <div key={c.name} className="py-1 border-b border-purple-200/50 last:border-0">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <span className="text-[12px] font-medium text-slate-700">{c.name}</span>
+                      <span className="text-[10px] text-slate-500 ml-1">{c.pos}</span>
+                    </div>
+                    <span className="text-[10px] font-mono text-purple-600">+{safeNum(c.avgDiff).toFixed(2)} avg</span>
                   </div>
-                  <span className="text-[10px] text-purple-600">{c.reason}</span>
+                  <div className="mt-0.5 flex flex-wrap gap-1.5">
+                    {c.cats.map((cat) => (
+                      <span key={cat.cat} className="text-[9px] text-purple-500">
+                        {cat.cat} +{safeNum(cat.diff).toFixed(1)}
+                      </span>
+                    ))}
+                  </div>
                 </div>
               ))}
             </div>
           )}
-          {positionSurplus.length > 0 && (
-            <div className="rounded-lg border border-blue-300 bg-blue-50/50 px-4 py-3">
-              <div className="text-[10px] font-semibold uppercase tracking-wider text-blue-700 mb-2">Position Surplus</div>
-              {positionSurplus.map((s, i) => (
-                <div key={i} className="flex items-center justify-between py-1 border-b border-blue-200/50 last:border-0">
-                  <span className="text-[12px] font-bold text-blue-700">{s.pos} x{s.count}</span>
-                  <span className="text-[10px] text-slate-500">{s.players.join(", ")}</span>
+        </div>
+      )}
+
+      {/* Gap Analysis */}
+      {gapPartners.length > 0 && (
+        <div className="mb-4 rounded-lg border border-indigo-300 bg-indigo-50/50">
+          <div className="border-b border-indigo-300 px-4 py-2.5">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-indigo-700">Gap Analysis</span>
+            <span className="ml-2 text-[10px] text-indigo-500">Complementary trade partners</span>
+          </div>
+          <div className="grid gap-0 sm:grid-cols-2 lg:grid-cols-3">
+            {gapPartners.map((partner) => (
+              <div key={partner.teamId} className="border-b border-r border-indigo-200 px-3 py-2.5 last:border-r-0">
+                <div className="text-[12px] font-medium text-slate-700">{partner.teamName}</div>
+                <div className="mt-1 text-[10px]">
+                  <span className="text-emerald-600">They need: </span>
+                  <span className="text-slate-600">{partner.theyNeed.join(", ")}</span>
                 </div>
-              ))}
-            </div>
-          )}
+                <div className="text-[10px]">
+                  <span className="text-blue-600">You need: </span>
+                  <span className="text-slate-600">{partner.youNeed.join(", ")}</span>
+                </div>
+                <div className="mt-0.5 text-[9px] text-indigo-400">
+                  Match score: {safeNum(partner.complementScore).toFixed(1)}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Metric Arbitrage */}
+      {arbitrageCandidates.length > 0 && (
+        <div className="mb-4 rounded-lg border border-orange-300 bg-orange-50/50">
+          <div className="border-b border-orange-300 px-4 py-2.5">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-orange-700">Metric Arbitrage</span>
+            <span className="ml-2 text-[10px] text-orange-500">Z-score rank exceeds ESPN rank (undervalued)</span>
+          </div>
+          <div className="grid gap-0 sm:grid-cols-2 lg:grid-cols-3">
+            {arbitrageCandidates.map((c) => (
+              <div key={c.name} className="border-b border-r border-orange-200 px-3 py-2.5 last:border-r-0">
+                <div className="flex items-start justify-between gap-1">
+                  <div>
+                    <div className="text-[12px] font-medium text-slate-700">{c.name}</div>
+                    <div className="text-[10px] text-slate-500">{c.pos} · {c.teamName}</div>
+                  </div>
+                  <div className="text-right shrink-0">
+                    <div className="text-[11px] font-mono font-bold text-orange-600">FAR {safeNum(c.far).toFixed(1)}</div>
+                  </div>
+                </div>
+                <div className="mt-1 text-[10px] text-slate-500">
+                  Z-rank #{c.farRank} vs ESPN #{c.espnRank}
+                  <span className="ml-1 text-orange-600 font-medium">(+{c.rankDiff} spots)</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Position Surplus */}
+      {positionSurplus.length > 0 && (
+        <div className="mb-4">
+          <div className="rounded-lg border border-blue-300 bg-blue-50/50 px-4 py-3">
+            <div className="text-[10px] font-semibold uppercase tracking-wider text-blue-700 mb-2">Position Surplus</div>
+            {positionSurplus.map((s, i) => (
+              <div key={i} className="flex items-center justify-between py-1 border-b border-blue-200/50 last:border-0">
+                <span className="text-[12px] font-bold text-blue-700">{s.pos} x{s.count}</span>
+                <span className="text-[10px] text-slate-500">{s.players.join(", ")}</span>
+              </div>
+            ))}
+          </div>
         </div>
       )}
 

--- a/web/src/lib/trade-analysis.ts
+++ b/web/src/lib/trade-analysis.ts
@@ -1,0 +1,329 @@
+import { mean, stddev } from "@/lib/z-scores";
+
+export interface ZScorePlayer {
+  name: string;
+  playerId: number;
+  pos: string;
+  proTeam: string;
+  isPitcher: boolean;
+  onTeamId: number;
+  seasonStats: Record<string, number>;
+  zScores: Record<string, number>;
+  zTotal: number;
+  far: number;
+  espnRank?: number;
+}
+
+export interface PlayerStats {
+  name: string;
+  pos: string;
+  seasonStats: Record<string, number>;
+  last30Stats: Record<string, number>;
+}
+
+export interface TeamCatStrength {
+  teamId: number;
+  teamName: string;
+  catZTotals: Record<string, number>;
+}
+
+export interface SurplusCategory {
+  cat: string;
+  rank: number;
+  teamTotal: number;
+  players: { name: string; pos: string; zScore: number }[];
+}
+
+export interface GapPartner {
+  teamId: number;
+  teamName: string;
+  theyNeed: string[];
+  youNeed: string[];
+  complementScore: number;
+}
+
+export interface SellHighCandidate {
+  name: string;
+  pos: string;
+  cats: { cat: string; seasonZ: number; last30Z: number; diff: number }[];
+  avgDiff: number;
+}
+
+export interface ArbitrageCandidate {
+  name: string;
+  pos: string;
+  proTeam: string;
+  teamName: string;
+  far: number;
+  farRank: number;
+  espnRank: number;
+  rankDiff: number;
+}
+
+const INVERT_CATS = new Set(["ERA", "WHIP", "L"]);
+
+export function safeNum(v: unknown): number {
+  if (typeof v !== "number" || !Number.isFinite(v)) return 0;
+  return v;
+}
+
+export function computeTeamCatStrengths(
+  players: ZScorePlayer[],
+  cats: string[],
+  teamNames: Map<number, string>,
+): TeamCatStrength[] {
+  const byTeam = new Map<number, ZScorePlayer[]>();
+  for (const p of players) {
+    if (p.onTeamId === 0) continue;
+    const list = byTeam.get(p.onTeamId) ?? [];
+    list.push(p);
+    byTeam.set(p.onTeamId, list);
+  }
+
+  const strengths: TeamCatStrength[] = [];
+  for (const [teamId, roster] of byTeam) {
+    const catZTotals: Record<string, number> = {};
+    for (const cat of cats) {
+      const total = roster.reduce((sum, p) => sum + safeNum(p.zScores[cat]), 0);
+      catZTotals[cat] = safeNum(total);
+    }
+    strengths.push({
+      teamId,
+      teamName: teamNames.get(teamId) ?? `Team ${teamId}`,
+      catZTotals,
+    });
+  }
+  return strengths;
+}
+
+export function rankTeamsByCategory(
+  strengths: TeamCatStrength[],
+  cat: string,
+): Record<number, number> {
+  const sorted = [...strengths]
+    .map((t) => ({ teamId: t.teamId, val: safeNum(t.catZTotals[cat]) }))
+    .sort((a, b) => b.val - a.val);
+
+  const result: Record<number, number> = {};
+  let rank = 1;
+  for (let i = 0; i < sorted.length; i++) {
+    if (i > 0 && sorted[i].val !== sorted[i - 1].val) {
+      rank = i + 1;
+    }
+    result[sorted[i].teamId] = rank;
+  }
+  return result;
+}
+
+export function findSurplusCategories(
+  players: ZScorePlayer[],
+  cats: string[],
+  myTeamId: number,
+  teamNames: Map<number, string>,
+): SurplusCategory[] {
+  const strengths = computeTeamCatStrengths(players, cats, teamNames);
+  if (strengths.length === 0) return [];
+
+  const surpluses: SurplusCategory[] = [];
+  for (const cat of cats) {
+    const ranks = rankTeamsByCategory(strengths, cat);
+    const myRank = ranks[myTeamId];
+    if (myRank === undefined || myRank > 3) continue;
+
+    const myStrength = strengths.find((s) => s.teamId === myTeamId);
+    const myPlayers = players
+      .filter((p) => p.onTeamId === myTeamId && safeNum(p.zScores[cat]) > 0)
+      .sort((a, b) => safeNum(b.zScores[cat]) - safeNum(a.zScores[cat]))
+      .slice(0, 5)
+      .map((p) => ({ name: p.name, pos: p.pos, zScore: safeNum(p.zScores[cat]) }));
+
+    if (myPlayers.length > 0) {
+      surpluses.push({
+        cat,
+        rank: myRank,
+        teamTotal: safeNum(myStrength?.catZTotals[cat]),
+        players: myPlayers,
+      });
+    }
+  }
+
+  return surpluses.sort((a, b) => a.rank - b.rank);
+}
+
+export function computeGapAnalysis(
+  players: ZScorePlayer[],
+  cats: string[],
+  myTeamId: number,
+  teamNames: Map<number, string>,
+): GapPartner[] {
+  const strengths = computeTeamCatStrengths(players, cats, teamNames);
+  const myStrength = strengths.find((s) => s.teamId === myTeamId);
+  if (!myStrength) return [];
+
+  const partners: GapPartner[] = [];
+  for (const opp of strengths) {
+    if (opp.teamId === myTeamId) continue;
+
+    const theyNeed: string[] = [];
+    const youNeed: string[] = [];
+    let complementScore = 0;
+
+    for (const cat of cats) {
+      const myVal = safeNum(myStrength.catZTotals[cat]);
+      const oppVal = safeNum(opp.catZTotals[cat]);
+      const diff = oppVal - myVal;
+      const threshold = 2.0;
+
+      if (diff > threshold) {
+        youNeed.push(cat);
+      } else if (diff < -threshold) {
+        theyNeed.push(cat);
+      }
+
+      if ((diff > threshold && myVal < 0) || (diff < -threshold && oppVal < 0)) {
+        complementScore += Math.abs(diff);
+      }
+    }
+
+    if (theyNeed.length > 0 && youNeed.length > 0) {
+      partners.push({
+        teamId: opp.teamId,
+        teamName: opp.teamName,
+        theyNeed,
+        youNeed,
+        complementScore: safeNum(complementScore),
+      });
+    }
+  }
+
+  return partners.sort((a, b) => b.complementScore - a.complementScore);
+}
+
+export function findSellHighCandidates(
+  myRoster: { name: string; pos: string }[],
+  allPlayers: ZScorePlayer[],
+  playerStatsMap: Map<string, PlayerStats>,
+  myTeamId: number,
+  batCats: string[],
+  pitCats: string[],
+): SellHighCandidate[] {
+  const batters = allPlayers.filter((p) => !p.isPitcher);
+  const pitchers = allPlayers.filter((p) => p.isPitcher);
+
+  const batDistributions: Record<string, { mu: number; sd: number }> = {};
+  for (const cat of batCats) {
+    const vals = batters
+      .map((p) => p.seasonStats[cat])
+      .filter((v) => v !== undefined && v !== null && Number.isFinite(v)) as number[];
+    if (vals.length === 0) {
+      batDistributions[cat] = { mu: 0, sd: 1 };
+    } else {
+      const mu = mean(vals);
+      batDistributions[cat] = { mu, sd: stddev(vals, mu) };
+    }
+  }
+
+  const pitDistributions: Record<string, { mu: number; sd: number }> = {};
+  for (const cat of pitCats) {
+    const vals = pitchers
+      .map((p) => p.seasonStats[cat])
+      .filter((v) => v !== undefined && v !== null && Number.isFinite(v)) as number[];
+    if (vals.length === 0) {
+      pitDistributions[cat] = { mu: 0, sd: 1 };
+    } else {
+      const mu = mean(vals);
+      pitDistributions[cat] = { mu, sd: stddev(vals, mu) };
+    }
+  }
+
+  const candidates: SellHighCandidate[] = [];
+
+  for (const rosterPlayer of myRoster) {
+    const zp = allPlayers.find(
+      (p) => p.name === rosterPlayer.name && p.onTeamId === myTeamId,
+    );
+    const ps = playerStatsMap.get(rosterPlayer.name);
+    if (!zp || !ps) continue;
+
+    const isPitcher = zp.isPitcher;
+    const cats = isPitcher ? pitCats : batCats;
+    const distributions = isPitcher ? pitDistributions : batDistributions;
+
+    const elevatedCats: SellHighCandidate["cats"] = [];
+
+    for (const cat of cats) {
+      const seasonZ = safeNum(zp.zScores[cat]);
+      const last30Val = ps.last30Stats[cat];
+      if (last30Val === undefined || last30Val === null || !Number.isFinite(last30Val)) continue;
+
+      const dist = distributions[cat];
+      if (!dist || dist.sd === 0) continue;
+
+      let last30Z = (last30Val - dist.mu) / dist.sd;
+      if (INVERT_CATS.has(cat)) last30Z = -last30Z;
+      last30Z = safeNum(last30Z);
+
+      const diff = last30Z - seasonZ;
+      if (diff > 0.5) {
+        elevatedCats.push({ cat, seasonZ, last30Z, diff: safeNum(diff) });
+      }
+    }
+
+    if (elevatedCats.length > 0) {
+      const avgDiff = safeNum(
+        elevatedCats.reduce((s, c) => s + c.diff, 0) / elevatedCats.length,
+      );
+      candidates.push({
+        name: rosterPlayer.name,
+        pos: rosterPlayer.pos,
+        cats: elevatedCats.sort((a, b) => b.diff - a.diff),
+        avgDiff,
+      });
+    }
+  }
+
+  return candidates.sort((a, b) => b.avgDiff - a.avgDiff);
+}
+
+export function findMetricArbitrage(
+  players: ZScorePlayer[],
+  myTeamId: number,
+  teamNames: Map<number, string>,
+): ArbitrageCandidate[] {
+  const rostered = players.filter((p) => p.onTeamId > 0 && p.onTeamId !== myTeamId);
+  const sortedByFar = [...rostered].sort((a, b) => b.far - a.far);
+
+  const farRankMap = new Map<number, number>();
+  let rank = 1;
+  for (let i = 0; i < sortedByFar.length; i++) {
+    if (i > 0 && sortedByFar[i].far !== sortedByFar[i - 1].far) {
+      rank = i + 1;
+    }
+    farRankMap.set(sortedByFar[i].playerId, rank);
+  }
+
+  const candidates: ArbitrageCandidate[] = [];
+  for (const p of rostered) {
+    const espnRank = p.espnRank;
+    if (espnRank === undefined || espnRank === null) continue;
+
+    const farRank = farRankMap.get(p.playerId);
+    if (farRank === undefined) continue;
+
+    const rankDiff = espnRank - farRank;
+    if (rankDiff >= 20 && p.far > 0) {
+      candidates.push({
+        name: p.name,
+        pos: p.pos,
+        proTeam: p.proTeam,
+        teamName: teamNames.get(p.onTeamId) ?? `Team ${p.onTeamId}`,
+        far: safeNum(p.far),
+        farRank,
+        espnRank,
+        rankDiff,
+      });
+    }
+  }
+
+  return candidates.sort((a, b) => b.rankDiff - a.rankDiff).slice(0, 10);
+}

--- a/web/src/tests/trade-analysis.test.ts
+++ b/web/src/tests/trade-analysis.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect } from "vitest";
+import {
+  safeNum,
+  findSurplusCategories,
+  computeGapAnalysis,
+  findSellHighCandidates,
+  findMetricArbitrage,
+  type ZScorePlayer,
+  type PlayerStats,
+} from "@/lib/trade-analysis";
+
+function makePlayer(overrides: Partial<ZScorePlayer> & { name: string }): ZScorePlayer {
+  return {
+    playerId: 0,
+    pos: "OF",
+    proTeam: "NYY",
+    isPitcher: false,
+    onTeamId: 1,
+    seasonStats: {},
+    zScores: {},
+    zTotal: 0,
+    far: 0,
+    ...overrides,
+  };
+}
+
+describe("safeNum", () => {
+  it("passes through finite numbers", () => {
+    expect(safeNum(42)).toBe(42);
+    expect(safeNum(-3.5)).toBe(-3.5);
+    expect(safeNum(0)).toBe(0);
+  });
+
+  it("returns 0 for NaN, Infinity, null, undefined", () => {
+    expect(safeNum(NaN)).toBe(0);
+    expect(safeNum(Infinity)).toBe(0);
+    expect(safeNum(-Infinity)).toBe(0);
+    expect(safeNum(null)).toBe(0);
+    expect(safeNum(undefined)).toBe(0);
+  });
+
+  it("returns 0 for non-number types", () => {
+    expect(safeNum("42")).toBe(0);
+    expect(safeNum(true)).toBe(0);
+  });
+});
+
+describe("findSurplusCategories", () => {
+  const teamNames = new Map([
+    [1, "My Team"],
+    [2, "Team B"],
+    [3, "Team C"],
+    [4, "Team D"],
+  ]);
+
+  it("identifies categories where my team ranks top-3", () => {
+    const players: ZScorePlayer[] = [
+      makePlayer({ name: "P1", onTeamId: 1, zScores: { HR: 2.0, SB: -0.5 }, far: 5 }),
+      makePlayer({ name: "P2", onTeamId: 1, zScores: { HR: 1.5, SB: 0.2 }, far: 4 }),
+      makePlayer({ name: "P3", onTeamId: 2, zScores: { HR: 0.5, SB: 1.0 }, far: 3 }),
+      makePlayer({ name: "P4", onTeamId: 3, zScores: { HR: 0.3, SB: 2.0 }, far: 2 }),
+      makePlayer({ name: "P5", onTeamId: 4, zScores: { HR: -0.5, SB: 1.5 }, far: 1 }),
+    ];
+    const result = findSurplusCategories(players, ["HR", "SB"], 1, teamNames);
+    const hrSurplus = result.find((s) => s.cat === "HR");
+    expect(hrSurplus).toBeDefined();
+    expect(hrSurplus!.rank).toBe(1);
+    expect(hrSurplus!.players[0].name).toBe("P1");
+    expect(hrSurplus!.players[1].name).toBe("P2");
+
+    const sbSurplus = result.find((s) => s.cat === "SB");
+    expect(sbSurplus).toBeUndefined();
+  });
+
+  it("returns empty array when no surplus categories exist", () => {
+    const players: ZScorePlayer[] = [
+      makePlayer({ name: "P1", onTeamId: 1, zScores: { HR: -1.0 }, far: 1 }),
+      makePlayer({ name: "P2", onTeamId: 2, zScores: { HR: 2.0 }, far: 5 }),
+      makePlayer({ name: "P3", onTeamId: 3, zScores: { HR: 1.5 }, far: 4 }),
+      makePlayer({ name: "P4", onTeamId: 4, zScores: { HR: 1.0 }, far: 3 }),
+    ];
+    const result = findSurplusCategories(players, ["HR"], 1, teamNames);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns empty when no players exist", () => {
+    expect(findSurplusCategories([], ["HR"], 1, teamNames)).toHaveLength(0);
+  });
+
+  it("handles NaN z-scores gracefully", () => {
+    const players: ZScorePlayer[] = [
+      makePlayer({ name: "P1", onTeamId: 1, zScores: { HR: NaN }, far: 0 }),
+      makePlayer({ name: "P2", onTeamId: 2, zScores: { HR: 1.0 }, far: 3 }),
+    ];
+    const result = findSurplusCategories(players, ["HR"], 1, teamNames);
+    expect(result).toHaveLength(0);
+  });
+
+  it("only lists players with positive z-scores as trade chips", () => {
+    const players: ZScorePlayer[] = [
+      makePlayer({ name: "P1", onTeamId: 1, zScores: { HR: 2.0 }, far: 5 }),
+      makePlayer({ name: "P2", onTeamId: 1, zScores: { HR: -0.5 }, far: 1 }),
+    ];
+    const result = findSurplusCategories(players, ["HR"], 1, new Map([[1, "My Team"]]));
+    expect(result).toHaveLength(1);
+    expect(result[0].players).toHaveLength(1);
+    expect(result[0].players[0].name).toBe("P1");
+  });
+});
+
+describe("findSellHighCandidates", () => {
+  it("flags players whose 30-day z-score exceeds season z-score by >0.5", () => {
+    const allPlayers: ZScorePlayer[] = [
+      makePlayer({
+        name: "Hot Hitter",
+        onTeamId: 1,
+        isPitcher: false,
+        seasonStats: { HR: 10, AVG: 0.250 },
+        zScores: { HR: 0.0, AVG: 0.0 },
+        far: 3,
+      }),
+      makePlayer({
+        name: "Other",
+        onTeamId: 2,
+        isPitcher: false,
+        seasonStats: { HR: 10, AVG: 0.250 },
+        zScores: { HR: 0.0, AVG: 0.0 },
+        far: 2,
+      }),
+    ];
+
+    const statsMap = new Map<string, PlayerStats>([
+      ["Hot Hitter", {
+        name: "Hot Hitter",
+        pos: "OF",
+        seasonStats: { HR: 10, AVG: 0.250 },
+        last30Stats: { HR: 25, AVG: 0.350 },
+      }],
+    ]);
+
+    const myRoster = [{ name: "Hot Hitter", pos: "OF" }];
+    const result = findSellHighCandidates(
+      myRoster, allPlayers, statsMap, 1,
+      ["HR", "AVG"], [],
+    );
+
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    expect(result[0].name).toBe("Hot Hitter");
+    expect(result[0].cats.length).toBeGreaterThan(0);
+    for (const cat of result[0].cats) {
+      expect(cat.diff).toBeGreaterThan(0.5);
+    }
+  });
+
+  it("does not flag players with similar 30-day and season z-scores", () => {
+    const allPlayers: ZScorePlayer[] = [
+      makePlayer({
+        name: "Steady",
+        onTeamId: 1,
+        isPitcher: false,
+        seasonStats: { HR: 10 },
+        zScores: { HR: 0.5 },
+        far: 3,
+      }),
+    ];
+
+    const statsMap = new Map<string, PlayerStats>([
+      ["Steady", {
+        name: "Steady",
+        pos: "1B",
+        seasonStats: { HR: 10 },
+        last30Stats: { HR: 11 },
+      }],
+    ]);
+
+    const result = findSellHighCandidates(
+      [{ name: "Steady", pos: "1B" }], allPlayers, statsMap, 1,
+      ["HR"], [],
+    );
+    expect(result).toHaveLength(0);
+  });
+
+  it("handles missing last30Stats gracefully", () => {
+    const allPlayers: ZScorePlayer[] = [
+      makePlayer({
+        name: "NoRecent",
+        onTeamId: 1,
+        seasonStats: { HR: 10 },
+        zScores: { HR: 0.5 },
+      }),
+    ];
+
+    const statsMap = new Map<string, PlayerStats>([
+      ["NoRecent", {
+        name: "NoRecent",
+        pos: "OF",
+        seasonStats: { HR: 10 },
+        last30Stats: {},
+      }],
+    ]);
+
+    const result = findSellHighCandidates(
+      [{ name: "NoRecent", pos: "OF" }], allPlayers, statsMap, 1,
+      ["HR"], [],
+    );
+    expect(result).toHaveLength(0);
+  });
+
+  it("handles NaN in last30Stats", () => {
+    const allPlayers: ZScorePlayer[] = [
+      makePlayer({
+        name: "BadData",
+        onTeamId: 1,
+        seasonStats: { HR: 10 },
+        zScores: { HR: 0.5 },
+      }),
+    ];
+
+    const statsMap = new Map<string, PlayerStats>([
+      ["BadData", {
+        name: "BadData",
+        pos: "OF",
+        seasonStats: { HR: 10 },
+        last30Stats: { HR: NaN },
+      }],
+    ]);
+
+    const result = findSellHighCandidates(
+      [{ name: "BadData", pos: "OF" }], allPlayers, statsMap, 1,
+      ["HR"], [],
+    );
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe("computeGapAnalysis", () => {
+  const teamNames = new Map([
+    [1, "My Team"],
+    [2, "Partner"],
+  ]);
+
+  it("identifies complementary trade partners", () => {
+    const players: ZScorePlayer[] = [
+      makePlayer({ name: "P1", onTeamId: 1, zScores: { HR: 3.0, SB: -2.0 } }),
+      makePlayer({ name: "P2", onTeamId: 2, zScores: { HR: -2.0, SB: 3.0 } }),
+    ];
+    const result = computeGapAnalysis(players, ["HR", "SB"], 1, teamNames);
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    const partner = result.find((p) => p.teamId === 2);
+    expect(partner).toBeDefined();
+    expect(partner!.theyNeed).toContain("HR");
+    expect(partner!.youNeed).toContain("SB");
+  });
+
+  it("returns empty when no complementary partners exist", () => {
+    const players: ZScorePlayer[] = [
+      makePlayer({ name: "P1", onTeamId: 1, zScores: { HR: 1.0 } }),
+      makePlayer({ name: "P2", onTeamId: 2, zScores: { HR: 1.0 } }),
+    ];
+    const result = computeGapAnalysis(players, ["HR"], 1, teamNames);
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe("findMetricArbitrage", () => {
+  const teamNames = new Map([
+    [1, "My Team"],
+    [2, "Other"],
+  ]);
+
+  it("flags players with high FAR but low ESPN rank", () => {
+    const players: ZScorePlayer[] = [
+      makePlayer({ name: "Hidden Gem", playerId: 100, onTeamId: 2, far: 8.0, espnRank: 200 }),
+      makePlayer({ name: "Properly Ranked", playerId: 101, onTeamId: 2, far: 5.0, espnRank: 10 }),
+    ];
+    const result = findMetricArbitrage(players, 1, teamNames);
+    const gem = result.find((c) => c.name === "Hidden Gem");
+    expect(gem).toBeDefined();
+    expect(gem!.rankDiff).toBeGreaterThanOrEqual(20);
+  });
+
+  it("excludes my own players", () => {
+    const players: ZScorePlayer[] = [
+      makePlayer({ name: "My Player", playerId: 100, onTeamId: 1, far: 8.0, espnRank: 200 }),
+    ];
+    const result = findMetricArbitrage(players, 1, teamNames);
+    expect(result).toHaveLength(0);
+  });
+
+  it("excludes players without espnRank", () => {
+    const players: ZScorePlayer[] = [
+      makePlayer({ name: "NoRank", playerId: 100, onTeamId: 2, far: 8.0 }),
+    ];
+    const result = findMetricArbitrage(players, 1, teamNames);
+    expect(result).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #33

## Changes
- **Surplus Detector**: Identifies categories where team ranks top-3 in the league, flags highest-contributing players as trade chips
- **Gap Analysis**: Shows per-opponent category differentials, highlights complementary trade partners (they're strong where you're weak and vice versa)
- **Sell-High Candidates**: Z-score based approach comparing 30-day z-scores to season z-scores, flags players exceeding baseline by >0.5 SD
- **Metric Arbitrage**: Flags other teams' players where z-score (FAR) rank significantly exceeds ESPN default rank (undervalued targets)

## Implementation
- Extracted pure analysis functions to `web/src/lib/trade-analysis.ts` for testability
- Added `espnRank` field to z-score API response (index in ESPN's default sort order)
- All numeric values sanitized for NaN/Infinity/null/division-by-zero
- Existing position surplus and trade builder/impact sections preserved

## Tests
20 new Vitest tests in `trade-analysis.test.ts` covering:
- Surplus detection logic (top-3 ranking, empty data, NaN handling, positive-only trade chips)
- Sell-high identification (z-score threshold, steady players, missing/NaN data)
- Gap analysis (complementary partners, no matches)
- Metric arbitrage (rank discrepancy, own-player exclusion, missing data)

All 114 tests pass. TypeScript compiles cleanly.