### PR TITLE
Add deep stat breakdown with z-score detail to My Roster

### DIFF
--- a/web/src/app/gm/roster/page.tsx
+++ b/web/src/app/gm/roster/page.tsx
@@ -151,13 +151,13 @@ function ExpandedDetail({
               const allVals = allZScores
                 .filter((p) => p.zScores[cat] !== undefined)
                 .map((p) => safeNum(p.zScores[cat]));
-              const pct = computePercentile(z, allVals);
+              const pct = allVals.length > 0 ? computePercentile(z, allVals) : null;
               const colorCls =
                 z > 0.5 ? "text-emerald-600" : z < -0.5 ? "text-red-600" : "text-slate-500";
               return (
                 <span key={cat} className={colorCls}>
                   {cat} {z >= 0 ? "+" : ""}{z.toFixed(1)}{" "}
-                  <span className="text-slate-400">top {100 - pct}%</span>
+                  <span className="text-slate-400">{pct !== null ? `top ${100 - pct}%` : "N/A"}</span>
                 </span>
               );
             })}
@@ -261,7 +261,7 @@ function PlayerRow({
           {/* FAR badge */}
           {zp && (
             <span className={`shrink-0 text-[9px] font-mono font-bold ${zColor(zp.zTotal)}`}>
-              {safeNum(zp.far).toFixed(1)}
+              {Number.isFinite(zp.far) ? zp.far.toFixed(1) : "N/A"}
             </span>
           )}
 

--- a/web/src/app/gm/roster/page.tsx
+++ b/web/src/app/gm/roster/page.tsx
@@ -3,7 +3,8 @@
 const IL_INJURY_STATUSES = new Set(["SEVEN_DAY_DL", "TEN_DAY_DL", "FIFTEEN_DAY_DL", "SIXTY_DAY_DL", "OUT"]);
 function isOnIL(status: string): boolean { return IL_INJURY_STATUSES.has(status); }
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
+import { computePercentile, trendDirection, safeNum } from "@/lib/roster-utils";
 
 interface RosterPlayer {
   name: string;
@@ -46,6 +47,8 @@ interface PlayerSeasonStats {
   pos: string;
   seasonStats: Record<string, number>;
   last7Stats: Record<string, number>;
+  last15Stats: Record<string, number>;
+  last30Stats: Record<string, number>;
 }
 
 const MY_TEAM_ID_KEY = "espnMyTeamId";
@@ -65,11 +68,127 @@ function zColor(z: number): string {
   return "text-red-600";
 }
 
+const BATTER_Z_CATS = ["AVG", "HR", "R", "RBI", "SB", "H", "BB", "TB"];
+const PITCHER_Z_CATS = ["K", "QS", "W", "SV", "HD", "ERA", "WHIP", "L"];
+const BATTER_TREND_CATS = ["HR", "RBI", "R", "SB"];
+const PITCHER_TREND_CATS = ["W", "K", "ERA", "WHIP"];
+const INVERT_TREND_CATS = new Set(["ERA", "WHIP"]);
+
 // Slot IDs
 const BATTER_SLOT_IDS = new Set([0, 1, 2, 3, 4, 5, 6, 7, 8, 12]);
 const PITCHER_SLOT_IDS = new Set([13, 14, 15]);
 const BENCH_SLOT_ID = 16;
 
+function TrendSparkline({ points, invert }: { points: (number | undefined | null)[]; invert?: boolean }) {
+  const valid = points.filter((v): v is number => v != null && Number.isFinite(v));
+  if (valid.length < 2) {
+    return <span className="text-[9px] text-slate-400">No data</span>;
+  }
+
+  const min = Math.min(...valid);
+  const max = Math.max(...valid);
+  const range = max - min || 1;
+  const w = 48;
+  const h = 16;
+  const pad = 2;
+
+  const pts = valid.map((v, i) => {
+    const x = pad + (i / (valid.length - 1)) * (w - 2 * pad);
+    let y = pad + (1 - (v - min) / range) * (h - 2 * pad);
+    if (invert) y = pad + ((v - min) / range) * (h - 2 * pad);
+    return `${x},${y}`;
+  });
+
+  const dir = trendDirection(invert ? valid.map((v) => -v) : valid);
+  const color = dir === "up" ? "#059669" : dir === "down" ? "#dc2626" : "#94a3b8";
+
+  return (
+    <svg width={w} height={h} className="inline-block align-middle">
+      <polyline points={pts.join(" ")} fill="none" stroke={color} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function ExpandedDetail({
+  player,
+  stats,
+  zp,
+  allZScores,
+}: {
+  player: RosterPlayer;
+  stats?: PlayerSeasonStats;
+  zp?: ZScorePlayer;
+  allZScores: ZScorePlayer[];
+}) {
+  const isPitcher = player.pos === "SP" || player.pos === "RP";
+  const cats = isPitcher ? PITCHER_Z_CATS : BATTER_Z_CATS;
+  const trendCats = isPitcher ? PITCHER_TREND_CATS : BATTER_TREND_CATS;
+
+  return (
+    <div className="bg-slate-50 border-b border-border px-3 py-3 space-y-3">
+      {/* Full season stats grid */}
+      {stats && (
+        <div>
+          <div className="text-[9px] font-semibold uppercase tracking-wider text-slate-400 mb-1">Season Stats</div>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-[10px] font-mono tabular-nums">
+            {Object.entries(stats.seasonStats).map(([cat, val]) => (
+              <span key={cat}>
+                <span className="text-slate-400">{cat}</span>{" "}
+                <span className="text-slate-700">{fmtStat(cat, safeNum(val))}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Z-score breakdown */}
+      {zp && (
+        <div>
+          <div className="text-[9px] font-semibold uppercase tracking-wider text-slate-400 mb-1">Z-Score Breakdown</div>
+          <div className="flex flex-wrap gap-x-3 gap-y-1 text-[10px] font-mono tabular-nums">
+            {cats.map((cat) => {
+              const z = safeNum(zp.zScores[cat]);
+              const allVals = allZScores
+                .filter((p) => p.zScores[cat] !== undefined)
+                .map((p) => safeNum(p.zScores[cat]));
+              const pct = computePercentile(z, allVals);
+              const colorCls =
+                z > 0.5 ? "text-emerald-600" : z < -0.5 ? "text-red-600" : "text-slate-500";
+              return (
+                <span key={cat} className={colorCls}>
+                  {cat} {z >= 0 ? "+" : ""}{z.toFixed(1)}{" "}
+                  <span className="text-slate-400">top {100 - pct}%</span>
+                </span>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Trend sparklines */}
+      {stats && (
+        <div>
+          <div className="text-[9px] font-semibold uppercase tracking-wider text-slate-400 mb-1">Trend (30d → 15d → 7d)</div>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 items-center text-[10px]">
+            {trendCats.map((cat) => {
+              const points = [
+                stats.last30Stats[cat],
+                stats.last15Stats[cat],
+                stats.last7Stats[cat],
+              ];
+              return (
+                <span key={cat} className="inline-flex items-center gap-1">
+                  <span className="text-slate-400 font-mono">{cat}</span>
+                  <TrendSparkline points={points} invert={INVERT_TREND_CATS.has(cat)} />
+                </span>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
 
 function PlayerRow({
   player,
@@ -77,83 +196,95 @@ function PlayerRow({
   zp,
   stats,
   showDetail,
+  expanded,
+  onToggle,
+  allZScores,
 }: {
   player: RosterPlayer;
   schedule: TeamSchedule | null;
   zp?: ZScorePlayer;
   stats?: PlayerSeasonStats;
   showDetail: boolean;
+  expanded: boolean;
+  onToggle: () => void;
+  allZScores: ZScorePlayer[];
 }) {
   const hasGame = !!schedule?.todayOpponent;
   const isInjured = player.injuryStatus !== "ACTIVE";
   const isPitcher = player.pos === "SP" || player.pos === "RP";
 
   return (
-    <div className="border-b border-border px-2 py-1.5">
-      <div className="flex items-center gap-2">
-        <span className="w-7 shrink-0 text-[10px] font-bold text-slate-600">{player.slotLabel}</span>
-        <span className={`min-w-0 w-[140px] truncate text-[12px] ${isInjured ? "text-slate-500" : "text-slate-700"}`}>
-          {player.name}
-        </span>
-        <span className="w-6 shrink-0 text-[10px] text-slate-500">{player.pos}</span>
-        <span className="w-7 shrink-0 text-[10px] text-slate-500">{player.proTeam}</span>
-
-        {showDetail && stats ? (
-          <div className="flex-1 flex items-center gap-2 justify-end text-[9px] font-mono text-slate-500 tabular-nums">
-            {!isPitcher ? (
-              <>
-                <span>{fmtStat("AVG", stats.seasonStats.AVG)}</span>
-                <span>{fmtStat("HR", stats.seasonStats.HR)} <span className="text-slate-400">HR</span></span>
-                <span>{fmtStat("RBI", stats.seasonStats.RBI)} <span className="text-slate-400">RBI</span></span>
-                <span>{fmtStat("SB", stats.seasonStats.SB)} <span className="text-slate-400">SB</span></span>
-              </>
-            ) : (
-              <>
-                <span>{fmtStat("ERA", stats.seasonStats.ERA)}</span>
-                <span>{fmtStat("WHIP", stats.seasonStats.WHIP)}</span>
-                <span>{fmtStat("K", stats.seasonStats.K)} <span className="text-slate-400">K</span></span>
-                <span>{fmtStat("IP", stats.seasonStats.IP)} <span className="text-slate-400">IP</span></span>
-              </>
-            )}
-          </div>
-        ) : (
-          <div className="flex-1 min-w-0">
-            {hasGame ? (
-              <span className="text-[10px] text-slate-600 whitespace-nowrap">
-                {schedule!.todayOpponent}
-                {schedule!.todayTime && (
-                  <span className="ml-1 text-slate-500">{schedule!.todayTime}</span>
-                )}
-              </span>
-            ) : (
-              <span className="text-[10px] text-slate-400">Off</span>
-            )}
-          </div>
-        )}
-
-        {/* FAR badge */}
-        {zp && (
-          <span className={`shrink-0 text-[9px] font-mono font-bold ${zColor(zp.zTotal)}`}>
-            {zp.far.toFixed(1)}
+    <>
+      <div className={`border-b border-border px-2 py-1.5 cursor-pointer hover:bg-slate-50 transition-colors ${expanded ? "bg-slate-50" : ""}`} onClick={onToggle}>
+        <div className="flex items-center gap-2">
+          <span className={`w-3 shrink-0 text-[9px] text-slate-400 transition-transform ${expanded ? "rotate-90" : ""}`}>▸</span>
+          <span className="w-7 shrink-0 text-[10px] font-bold text-slate-600">{player.slotLabel}</span>
+          <span className={`min-w-0 w-[140px] truncate text-[12px] ${isInjured ? "text-slate-500" : "text-slate-700"}`}>
+            {player.name}
           </span>
-        )}
+          <span className="w-6 shrink-0 text-[10px] text-slate-500">{player.pos}</span>
+          <span className="w-7 shrink-0 text-[10px] text-slate-500">{player.proTeam}</span>
 
-        {/* Games this week */}
-        {schedule && (
-          <span className={`shrink-0 text-[10px] tabular-nums font-semibold ${
-            schedule.weekGames >= 5 ? "text-emerald-600" :
-            schedule.weekGames >= 3 ? "text-orange-600" : "text-slate-600"
-          }`}>{schedule.weekGames}G</span>
-        )}
+          {showDetail && stats ? (
+            <div className="flex-1 flex items-center gap-2 justify-end text-[9px] font-mono text-slate-500 tabular-nums">
+              {!isPitcher ? (
+                <>
+                  <span>{fmtStat("AVG", stats.seasonStats.AVG)}</span>
+                  <span>{fmtStat("HR", stats.seasonStats.HR)} <span className="text-slate-400">HR</span></span>
+                  <span>{fmtStat("RBI", stats.seasonStats.RBI)} <span className="text-slate-400">RBI</span></span>
+                  <span>{fmtStat("SB", stats.seasonStats.SB)} <span className="text-slate-400">SB</span></span>
+                </>
+              ) : (
+                <>
+                  <span>{fmtStat("ERA", stats.seasonStats.ERA)}</span>
+                  <span>{fmtStat("WHIP", stats.seasonStats.WHIP)}</span>
+                  <span>{fmtStat("K", stats.seasonStats.K)} <span className="text-slate-400">K</span></span>
+                  <span>{fmtStat("IP", stats.seasonStats.IP)} <span className="text-slate-400">IP</span></span>
+                </>
+              )}
+            </div>
+          ) : (
+            <div className="flex-1 min-w-0">
+              {hasGame ? (
+                <span className="text-[10px] text-slate-600 whitespace-nowrap">
+                  {schedule!.todayOpponent}
+                  {schedule!.todayTime && (
+                    <span className="ml-1 text-slate-500">{schedule!.todayTime}</span>
+                  )}
+                </span>
+              ) : (
+                <span className="text-[10px] text-slate-400">Off</span>
+              )}
+            </div>
+          )}
 
-        {/* Injury */}
-        {isInjured && (
-          <span className={`shrink-0 text-[10px] font-bold ${player.injuryColor}`}>
-            {player.injuryLabel}
-          </span>
-        )}
+          {/* FAR badge */}
+          {zp && (
+            <span className={`shrink-0 text-[9px] font-mono font-bold ${zColor(zp.zTotal)}`}>
+              {safeNum(zp.far).toFixed(1)}
+            </span>
+          )}
+
+          {/* Games this week */}
+          {schedule && (
+            <span className={`shrink-0 text-[10px] tabular-nums font-semibold ${
+              schedule.weekGames >= 5 ? "text-emerald-600" :
+              schedule.weekGames >= 3 ? "text-orange-600" : "text-slate-600"
+            }`}>{schedule.weekGames}G</span>
+          )}
+
+          {/* Injury */}
+          {isInjured && (
+            <span className={`shrink-0 text-[10px] font-bold ${player.injuryColor}`}>
+              {player.injuryLabel}
+            </span>
+          )}
+        </div>
       </div>
-    </div>
+      {expanded && (
+        <ExpandedDetail player={player} stats={stats} zp={zp} allZScores={allZScores} />
+      )}
+    </>
   );
 }
 
@@ -314,6 +445,7 @@ export default function RosterPage() {
   const [zScoreMap, setZScoreMap] = useState<Map<string, ZScorePlayer>>(new Map());
   const [playerStatsMap, setPlayerStatsMap] = useState<Map<string, PlayerSeasonStats>>(new Map());
   const [showStats, setShowStats] = useState(true);
+  const [expandedPlayer, setExpandedPlayer] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -380,6 +512,11 @@ export default function RosterPage() {
       .catch(() => setFallbackTeam(teams[0]));
   }, [myTeam, teams]);
 
+  const allZScores = useMemo(() => Array.from(zScoreMap.values()), [zScoreMap]);
+  const togglePlayer = useCallback((name: string) => {
+    setExpandedPlayer((prev) => (prev === name ? null : name));
+  }, []);
+
   const roster = resolvedTeam?.roster ?? [];
   const batters = useMemo(() => roster.filter((p) => BATTER_SLOT_IDS.has(p.slotId)).sort((a, b) => a.slotId - b.slotId), [roster]);
   const pitchers = useMemo(() => roster.filter((p) => PITCHER_SLOT_IDS.has(p.slotId)).sort((a, b) => a.slotId - b.slotId), [roster]);
@@ -399,7 +536,23 @@ export default function RosterPage() {
     );
   }
 
-  const sectionProps = { schedule, zScoreMap, playerStatsMap, showDetail: showStats };
+  const Section = ({ label, players, borderColor = "border-border" }: { label: string; players: RosterPlayer[]; borderColor?: string }) => (
+    <div className={`rounded-lg border ${borderColor} bg-surface`}>
+      <div className={`border-b ${borderColor} px-3 py-2 flex items-center justify-between`}>
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-600">{label}</span>
+        <span className="text-[10px] tabular-nums text-slate-400">{players.length}</span>
+      </div>
+      {players.map((p, i) => (
+        <PlayerRow key={i} player={p} schedule={schedule[p.proTeam] ?? null}
+          zp={zScoreMap.get(p.name)} stats={playerStatsMap.get(p.name)} showDetail={showStats}
+          expanded={expandedPlayer === p.name} onToggle={() => togglePlayer(p.name)}
+          allZScores={allZScores} />
+      ))}
+      {players.length === 0 && (
+        <div className="px-3 py-3 text-[11px] text-slate-400">-</div>
+      )}
+    </div>
+  );
 
   return (
     <div className="mx-auto max-w-6xl px-4 py-6">

--- a/web/src/lib/roster-utils.ts
+++ b/web/src/lib/roster-utils.ts
@@ -1,0 +1,33 @@
+export function computePercentile(
+  playerZ: number,
+  allZValues: number[],
+): number {
+  if (allZValues.length === 0) return 0;
+  const below = allZValues.filter((z) => z < playerZ).length;
+  return Math.round((below / allZValues.length) * 100);
+}
+
+export type TrendDirection = "up" | "down" | "flat" | "nodata";
+
+export function trendDirection(points: (number | undefined | null)[]): TrendDirection {
+  const valid = points.filter(
+    (v): v is number => v != null && Number.isFinite(v),
+  );
+  if (valid.length < 2) return "nodata";
+
+  const first = valid[0];
+  const last = valid[valid.length - 1];
+  const diff = last - first;
+  const range = Math.max(...valid) - Math.min(...valid);
+
+  if (range === 0) return "flat";
+  const threshold = range * 0.1;
+  if (diff > threshold) return "up";
+  if (diff < -threshold) return "down";
+  return "flat";
+}
+
+export function safeNum(val: number | undefined | null): number {
+  if (val == null || !Number.isFinite(val)) return 0;
+  return val;
+}

--- a/web/src/lib/roster-utils.ts
+++ b/web/src/lib/roster-utils.ts
@@ -1,3 +1,8 @@
+/**
+ * Exclusive percentile rank: percentage of values strictly below playerZ.
+ * Returns 0 for the lowest value, 100 when playerZ exceeds all values.
+ * Callers should guard against empty arrays before calling.
+ */
 export function computePercentile(
   playerZ: number,
   allZValues: number[],

--- a/web/src/tests/roster-utils.test.ts
+++ b/web/src/tests/roster-utils.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { computePercentile, trendDirection, safeNum } from "@/lib/roster-utils";
+
+describe("computePercentile", () => {
+  it("returns correct percentile for a value in the middle", () => {
+    const allZ = [-2, -1, 0, 1, 2];
+    expect(computePercentile(0, allZ)).toBe(40);
+    expect(computePercentile(2, allZ)).toBe(80);
+    expect(computePercentile(-2, allZ)).toBe(0);
+  });
+
+  it("returns 100 when player is above all values", () => {
+    expect(computePercentile(5, [1, 2, 3])).toBe(100);
+  });
+
+  it("returns 0 for empty array", () => {
+    expect(computePercentile(1.5, [])).toBe(0);
+  });
+
+  it("handles single element array", () => {
+    expect(computePercentile(1, [1])).toBe(0);
+    expect(computePercentile(2, [1])).toBe(100);
+  });
+
+  it("handles duplicate values", () => {
+    const allZ = [1, 1, 1, 2, 3];
+    expect(computePercentile(1, allZ)).toBe(0);
+    expect(computePercentile(2, allZ)).toBe(60);
+  });
+});
+
+describe("trendDirection", () => {
+  it("detects upward trend", () => {
+    expect(trendDirection([1, 3, 5])).toBe("up");
+  });
+
+  it("detects downward trend", () => {
+    expect(trendDirection([5, 3, 1])).toBe("down");
+  });
+
+  it("detects flat trend", () => {
+    expect(trendDirection([3, 3, 3])).toBe("flat");
+  });
+
+  it("returns nodata for fewer than 2 valid points", () => {
+    expect(trendDirection([5])).toBe("nodata");
+    expect(trendDirection([])).toBe("nodata");
+    expect(trendDirection([undefined, null])).toBe("nodata");
+  });
+
+  it("handles null and undefined values in the array", () => {
+    expect(trendDirection([null, 1, undefined, 5])).toBe("up");
+  });
+
+  it("handles Infinity and NaN gracefully", () => {
+    expect(trendDirection([Infinity, 1, 2])).toBe("up");
+    expect(trendDirection([NaN, 1, 5])).toBe("up");
+    expect(trendDirection([Infinity, NaN])).toBe("nodata");
+  });
+});
+
+describe("safeNum", () => {
+  it("returns 0 for null, undefined, NaN, Infinity", () => {
+    expect(safeNum(null)).toBe(0);
+    expect(safeNum(undefined)).toBe(0);
+    expect(safeNum(NaN)).toBe(0);
+    expect(safeNum(Infinity)).toBe(0);
+    expect(safeNum(-Infinity)).toBe(0);
+  });
+
+  it("returns the value for valid numbers", () => {
+    expect(safeNum(42)).toBe(42);
+    expect(safeNum(-3.14)).toBe(-3.14);
+    expect(safeNum(0)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Expandable player rows on `/gm/roster` with click-to-expand disclosure triangle
- Full season stats grid showing all counting and rate stats
- Per-category z-score breakdown with league percentile (color coded: green z > 0.5, red z < -0.5)
- Trend sparklines (inline SVG) for key stats using last 30d/15d/7d data, with inverted rendering for ERA/WHIP
- Utility functions (`computePercentile`, `trendDirection`, `safeNum`) in `roster-utils.ts` with edge case sanitization for Infinity, NaN, null, and division by zero
- 13 new Vitest tests covering percentile calculation, trend direction logic, and numeric sanitization

Closes #35

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes (110 tests, 0 failures)
- [ ] Manual: click a player row to expand, verify stats/z-scores/sparklines render
- [ ] Manual: verify "No data" shows for players with missing trend data
- [ ] Manual: verify color coding on z-score values (green/red/neutral)