### PR TITLE
Add assistant GM vision: 7 enhanced pages with live analytics

### DIFF
--- a/web/src/app/category-intel/page.tsx
+++ b/web/src/app/category-intel/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo } from "react";
 import {
   BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell,
 } from "recharts";
+import { LOWER_IS_BETTER } from "@/lib/category-weights";
 
 interface CategoryWeights {
   weights: Record<string, number>;
@@ -13,13 +14,30 @@ interface CategoryWeights {
   sample_sizes: Record<string, number>;
 }
 
+interface LiveTeam {
+  teamId: number;
+  teamName: string;
+  categories: Record<string, number>;
+  ranks: Record<string, number>;
+}
+
+interface LiveStatsData {
+  myTeamId: number;
+  teams: LiveTeam[];
+}
+
 export default function CategoryIntelPage() {
   const [data, setData] = useState<CategoryWeights | null>(null);
+  const [liveData, setLiveData] = useState<LiveStatsData | null>(null);
 
   useEffect(() => {
     fetch("/api/weights")
       .then((r) => r.json())
       .then((d) => { if (!d.error) setData(d); });
+    fetch("/api/espn/league-stats?scope=season")
+      .then((r) => r.json())
+      .then((d) => { if (!d.error && d.teams) setLiveData(d); })
+      .catch(() => {});
   }, []);
 
   const chartData = useMemo(() => {
@@ -83,6 +101,85 @@ export default function CategoryIntelPage() {
           </span>
         </div>
       </div>
+
+      {/* In-Season Category Standings */}
+      {liveData && data && (
+        <div className="mb-6 rounded-lg border border-border bg-surface">
+          <div className="border-b border-border px-4 py-2 flex items-center justify-between">
+            <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-500">
+              In-Season Category Standings
+            </span>
+            <span className="text-[9px] text-slate-400">Your rank in each category, colored by weight tier</span>
+          </div>
+          <div className="px-4 py-4">
+            {(() => {
+              const myTeam = liveData.teams.find((t) => t.teamId === liveData.myTeamId);
+              if (!myTeam) return <div className="text-[11px] text-slate-500">No data</div>;
+
+              const catEntries = sorted.map((d) => {
+                const rank = myTeam.ranks[d.category] ?? 0;
+                const value = myTeam.categories[d.category] ?? 0;
+                return { ...d, rank, value };
+              });
+
+              return (
+                <div className="space-y-4">
+                  <div className="grid grid-cols-4 sm:grid-cols-8 gap-2">
+                    {catEntries.map((c) => {
+                      const rankColor =
+                        c.rank <= 3 ? "bg-emerald-500 text-white" :
+                        c.rank <= 6 ? "bg-yellow-400 text-yellow-900" :
+                        "bg-red-500 text-white";
+                      const tierBorder =
+                        Math.abs(c.weight) >= 0.09 ? "border-orange-300" :
+                        Math.abs(c.weight) >= 0.05 ? "border-blue-300" :
+                        "border-slate-200";
+                      const fmtVal = LOWER_IS_BETTER.has(c.category)
+                        ? c.value.toFixed(c.category === "L" ? 0 : 2)
+                        : c.category === "AVG" ? c.value.toFixed(3)
+                        : String(Math.round(c.value));
+                      return (
+                        <div key={c.category} className={`rounded-lg border p-2 text-center ${tierBorder}`}>
+                          <div className="text-[10px] font-bold text-slate-600">{c.category}</div>
+                          <div className={`mt-1 inline-flex items-center justify-center w-7 h-7 rounded-full text-[12px] font-bold ${rankColor}`}>
+                            {c.rank}
+                          </div>
+                          <div className="mt-1 text-[10px] font-mono tabular-nums text-slate-600">{fmtVal}</div>
+                          <div className="text-[8px] text-slate-400">
+                            wt: {(Math.abs(c.weight) * 100).toFixed(1)}%
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+
+                  {/* Weighted strength summary */}
+                  {(() => {
+                    const strong = catEntries.filter((c) => c.rank <= 3 && Math.abs(c.weight) >= 0.05);
+                    const weak = catEntries.filter((c) => c.rank >= 8 && Math.abs(c.weight) >= 0.05);
+                    return (
+                      <div className="flex flex-wrap gap-4 pt-2 border-t border-border text-[11px]">
+                        {strong.length > 0 && (
+                          <div>
+                            <span className="text-emerald-600 font-semibold">Strong in high-weight: </span>
+                            <span className="text-slate-600">{strong.map((c) => c.category).join(", ")}</span>
+                          </div>
+                        )}
+                        {weak.length > 0 && (
+                          <div>
+                            <span className="text-red-600 font-semibold">Weak in high-weight: </span>
+                            <span className="text-slate-600">{weak.map((c) => c.category).join(", ")}</span>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })()}
+                </div>
+              );
+            })()}
+          </div>
+        </div>
+      )}
 
       <div className="grid gap-4 lg:grid-cols-2">
         {/* All Weights */}

--- a/web/src/app/gm/layout.tsx
+++ b/web/src/app/gm/layout.tsx
@@ -8,6 +8,7 @@ const SUB_LINKS = [
   { href: "/gm/roster", label: "My Roster" },
   { href: "/gm/diagnosis", label: "Diagnosis" },
   { href: "/gm/bullpen", label: "Bullpen" },
+  { href: "/gm/schedule-outlook", label: "Timeline" },
   { href: "/gm/category-breakdown", label: "Category Breakdown" },
   { href: "/gm/h2h", label: "Team H2H" },
   { href: "/gm/free-agents", label: "Free Agents" },

--- a/web/src/app/gm/page.tsx
+++ b/web/src/app/gm/page.tsx
@@ -40,12 +40,49 @@ interface LeagueStatsData {
   averages: Record<string, number>;
 }
 
-const POWER_CATS = ["TB", "HR", "R", "RBI"];
+interface CategoryRanking {
+  cat: string;
+  weight: number;
+  rank: number;
+  value: number;
+  leaderValue: number;
+  gap: number;
+  tier: string;
+  tierLabel: string;
+  isPunt: boolean;
+}
+
+interface ActionItem {
+  priority: "HIGH" | "MEDIUM" | "LOW";
+  type: string;
+  message: string;
+}
+
+interface DiagnosisData {
+  teamName: string;
+  categoryRankings: CategoryRanking[];
+  actionItems: ActionItem[];
+}
+
+const ALL_CATS = ["TB", "HR", "R", "RBI", "H", "W", "K", "WHIP", "QS", "ERA", "SB", "BB", "AVG", "L", "HD", "SV"];
 const IL_STATUSES = new Set(["SEVEN_DAY_DL", "TEN_DAY_DL", "FIFTEEN_DAY_DL", "SIXTY_DAY_DL", "OUT"]);
+
+function rankColor(rank: number): string {
+  if (rank <= 3) return "bg-emerald-500 text-white";
+  if (rank <= 6) return "bg-yellow-400 text-yellow-900";
+  return "bg-red-500 text-white";
+}
+
+function rankBorderColor(rank: number): string {
+  if (rank <= 3) return "border-emerald-300";
+  if (rank <= 6) return "border-yellow-300";
+  return "border-red-300";
+}
 
 export default function GmDashboard() {
   const [matchup, setMatchup] = useState<MatchupData | null>(null);
   const [leagueStats, setLeagueStats] = useState<LeagueStatsData | null>(null);
+  const [diagnosis, setDiagnosis] = useState<DiagnosisData | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -53,11 +90,13 @@ export default function GmDashboard() {
     Promise.all([
       fetch("/api/espn/matchup").then((r) => r.json()).catch(() => ({})),
       fetch("/api/espn/league-stats").then((r) => r.json()).catch(() => ({})),
+      fetch("/api/analysis/roster-diagnosis").then((r) => r.json()).catch(() => ({})),
     ])
-      .then(([m, ls]) => {
+      .then(([m, ls, diag]) => {
         if (m.error) { setError(m.error); return; }
         if (!m.error) setMatchup(m);
         if (!ls.error) setLeagueStats(ls);
+        if (!diag.error && diag.actionItems) setDiagnosis(diag);
       })
       .catch(() => setError("FETCH_FAILED"))
       .finally(() => setLoading(false));
@@ -95,17 +134,25 @@ export default function GmDashboard() {
     return { winning, losing, close };
   }, [matchup]);
 
-  const powerProfile = useMemo(() => {
-    if (!myTeam || !leagueStats) return null;
-    return POWER_CATS.map((cat) => {
-      const myVal = sanitizeNum(myTeam.categories[cat]);
-      const avg = sanitizeNum(leagueStats.averages[cat]);
-      const rank = sanitizeNum(myTeam.ranks[cat]);
-      const delta = sanitizeNum(myTeam.deltas[cat]);
-      const pctOfAvg = avg > 0 ? (myVal / avg) * 100 : 100;
-      return { cat, myVal, avg, rank, delta, pctOfAvg, weight: CATEGORY_WEIGHTS[cat] ?? 0 };
-    });
-  }, [myTeam, leagueStats]);
+  const categoryGrid = useMemo(() => {
+    if (!myTeam) return [];
+    return ALL_CATS.map((cat) => ({
+      cat,
+      rank: sanitizeNum(myTeam.ranks[cat], 10),
+      value: sanitizeNum(myTeam.categories[cat]),
+      delta: sanitizeNum(myTeam.deltas[cat]),
+      weight: CATEGORY_WEIGHTS[cat] ?? 0,
+      tier: categoryTier(cat),
+      isPunt: isPunt(cat),
+    }));
+  }, [myTeam]);
+
+  const topActions = useMemo(() => {
+    if (!diagnosis) return [];
+    return diagnosis.actionItems
+      .filter((a) => a.priority === "HIGH")
+      .slice(0, 4);
+  }, [diagnosis]);
 
   if (loading) return <div className="flex h-64 items-center justify-center text-slate-500">Loading dashboard...</div>;
   if (error === "ESPN_CREDS_MISSING" || error === "MY_ESPN_TEAM_ID_MISSING") {
@@ -175,120 +222,132 @@ export default function GmDashboard() {
           </div>
         )}
 
-        {/* Roster Health */}
+        {/* Action Items from Diagnosis */}
         <div className="rounded-lg border border-border bg-surface">
-          <div className="border-b border-border px-4 py-2">
-            <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-500">Roster Health</span>
+          <div className="border-b border-border px-4 py-2 flex items-center justify-between">
+            <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-500">Action Items</span>
+            {topActions.length > 0 && (
+              <a href="/gm/diagnosis" className="text-[10px] text-orange-600 hover:text-orange-700">View all</a>
+            )}
           </div>
-          <div className="px-4 py-4">
-            {injuredPlayers.length === 0 ? (
-              <div className="flex items-center gap-2">
-                <span className="text-[13px] text-emerald-600 font-semibold">All healthy</span>
-                <span className="text-[11px] text-slate-400">No players on IL</span>
+          <div className="px-4 py-3">
+            {topActions.length > 0 ? (
+              <div className="space-y-2">
+                {topActions.map((action, i) => (
+                  <div key={i} className="flex items-start gap-2">
+                    <span className={`shrink-0 mt-0.5 text-[9px] font-bold rounded px-1.5 py-0.5 ${
+                      action.type === "DROP" ? "bg-red-100 text-red-700" :
+                      action.type === "STREAM" ? "bg-blue-100 text-blue-700" :
+                      action.type === "TRADE" ? "bg-purple-100 text-purple-700" :
+                      action.type === "IMPROVE" ? "bg-orange-100 text-orange-700" :
+                      "bg-slate-100 text-slate-600"
+                    }`}>{action.type}</span>
+                    <span className="text-[12px] text-slate-700 leading-snug">{action.message}</span>
+                  </div>
+                ))}
               </div>
             ) : (
-              <div>
-                <div className="text-[11px] text-red-600 font-semibold mb-2">{injuredPlayers.length} on IL</div>
-                <div className="space-y-1">
-                  {injuredPlayers.map((p, i) => (
-                    <div key={i} className="flex items-center gap-2 text-[11px]">
-                      <span className="text-slate-700">{p.name}</span>
-                      <span className="text-slate-400">{p.pos}</span>
-                      <span className="text-red-500 text-[10px] font-bold">IL</span>
-                    </div>
-                  ))}
-                </div>
+              <div className="space-y-2">
+                {categoryInsights.losing.length > 0 && (
+                  <a href="/gm/matchup" className="flex items-center gap-2 text-[12px] text-red-600 hover:text-red-700">
+                    <span className="font-semibold">Losing {categoryInsights.losing.length} non-punt categories</span>
+                    <span className="text-slate-400">({categoryInsights.losing.map((c) => c.cat).join(", ")})</span>
+                  </a>
+                )}
+                {injuredPlayers.length > 0 && (
+                  <a href="/gm/roster" className="flex items-center gap-2 text-[12px] text-orange-600 hover:text-orange-700">
+                    <span className="font-semibold">{injuredPlayers.length} players on IL</span>
+                    <span className="text-slate-400">Check roster for streaming slots</span>
+                  </a>
+                )}
+                <a href="/gm/today" className="flex items-center gap-2 text-[12px] text-slate-600 hover:text-slate-700">
+                  <span className="font-semibold">View today&apos;s games and lineup</span>
+                </a>
+                <a href="/gm/free-agents" className="flex items-center gap-2 text-[12px] text-slate-600 hover:text-slate-700">
+                  <span className="font-semibold">Browse free agent recommendations</span>
+                </a>
               </div>
             )}
           </div>
         </div>
 
-        {/* Power Profile (Issue #64) */}
-        {powerProfile && (
+        {/* Category Health Grid */}
+        {categoryGrid.length > 0 && (
           <div className="rounded-lg border border-border bg-surface lg:col-span-2">
             <div className="border-b border-border px-4 py-2 flex items-center justify-between">
-              <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-500">Power Profile</span>
-              <span className="text-[9px] text-slate-400">TB, HR, R, RBI: highest-weight categories</span>
+              <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-500">Category Health</span>
+              <span className="text-[9px] text-slate-400">All 16 categories, sorted by weight</span>
             </div>
             <div className="px-4 py-4">
-              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-                {powerProfile.map((p) => {
-                  const barWidth = Math.min(100, Math.max(0, p.pctOfAvg));
-                  const isAbove = p.delta > 0;
-                  return (
-                    <div key={p.cat} className="space-y-1">
-                      <div className="flex items-baseline justify-between">
-                        <span className="text-[12px] font-bold text-slate-700">{p.cat}</span>
-                        <span className="text-[10px] text-slate-400">wt: {(p.weight * 100).toFixed(1)}%</span>
-                      </div>
-                      <div className="flex items-baseline gap-2">
-                        <span className="text-[18px] font-bold tabular-nums text-slate-800">{Math.round(p.myVal)}</span>
-                        <span className={`text-[11px] font-semibold ${isAbove ? "text-emerald-600" : "text-red-600"}`}>
-                          {isAbove ? "+" : ""}{Math.round(p.delta)} vs avg
-                        </span>
-                      </div>
-                      {/* Bar chart vs league average */}
-                      <div className="h-2 rounded-full bg-slate-200 overflow-hidden">
-                        <div
-                          className={`h-full rounded-full transition-all ${isAbove ? "bg-emerald-500" : "bg-red-400"}`}
-                          style={{ width: `${barWidth}%` }}
-                        />
-                      </div>
-                      <div className="flex items-center justify-between text-[9px] text-slate-400">
-                        <span>Avg: {Math.round(p.avg)}</span>
-                        <span>Rank: #{p.rank}</span>
-                      </div>
+              <div className="grid grid-cols-4 sm:grid-cols-8 gap-2">
+                {categoryGrid.map((c) => (
+                  <div key={c.cat} className={`rounded-lg border p-2 text-center ${rankBorderColor(c.rank)} ${c.isPunt ? "opacity-50" : ""}`}>
+                    <div className="text-[10px] font-bold text-slate-600">{c.cat}</div>
+                    <div className={`mt-1 inline-flex items-center justify-center w-7 h-7 rounded-full text-[12px] font-bold ${rankColor(c.rank)}`}>
+                      {c.rank}
                     </div>
-                  );
-                })}
-              </div>
-
-              {/* Power surplus/deficit summary */}
-              <div className="mt-4 pt-3 border-t border-border flex flex-wrap gap-3 text-[10px]">
-                {powerProfile.filter((p) => p.delta > 0).length > 0 && (
-                  <span className="text-emerald-600 font-semibold">
-                    Surplus: {powerProfile.filter((p) => p.delta > 0).map((p) => p.cat).join(", ")}
-                  </span>
-                )}
-                {powerProfile.filter((p) => p.delta < 0).length > 0 && (
-                  <span className="text-red-600 font-semibold">
-                    Deficit: {powerProfile.filter((p) => p.delta < 0).map((p) => p.cat).join(", ")}
-                  </span>
-                )}
+                    <div className={`mt-1 text-[10px] font-semibold ${c.delta > 0 ? "text-emerald-600" : c.delta < 0 ? "text-red-600" : "text-slate-400"}`}>
+                      {c.delta > 0 ? "+" : ""}{LOWER_IS_BETTER.has(c.cat)
+                        ? c.delta.toFixed(c.cat === "AVG" ? 3 : 2)
+                        : Math.round(c.delta)
+                      }
+                    </div>
+                    <div className="text-[8px] text-slate-400 mt-0.5">
+                      {c.tier === "high" ? "HIGH" : c.tier === "medium" ? "MED" : c.tier === "low" ? "LOW" : "PUNT"}
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
           </div>
         )}
 
-        {/* Action Items */}
+        {/* Roster Alerts */}
         <div className="rounded-lg border border-border bg-surface lg:col-span-2">
           <div className="border-b border-border px-4 py-2">
-            <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-500">Quick Actions</span>
+            <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-500">Roster Alerts</span>
           </div>
-          <div className="px-4 py-3 space-y-2">
-            {categoryInsights.losing.length > 0 && (
-              <a href="/gm/matchup" className="flex items-center gap-2 text-[12px] text-red-600 hover:text-red-700">
-                <span className="font-semibold">Losing {categoryInsights.losing.length} non-punt categories</span>
-                <span className="text-slate-400">({categoryInsights.losing.map((c) => c.cat).join(", ")})</span>
-              </a>
-            )}
-            {injuredPlayers.length > 0 && (
-              <a href="/gm/roster" className="flex items-center gap-2 text-[12px] text-orange-600 hover:text-orange-700">
-                <span className="font-semibold">{injuredPlayers.length} players on IL</span>
-                <span className="text-slate-400">Check roster for streaming slots</span>
-              </a>
-            )}
-            <a href="/gm/today" className="flex items-center gap-2 text-[12px] text-slate-600 hover:text-slate-700">
-              <span className="font-semibold">View today&apos;s games and lineup</span>
-            </a>
-            <a href="/gm/free-agents" className="flex items-center gap-2 text-[12px] text-slate-600 hover:text-slate-700">
-              <span className="font-semibold">Browse free agent recommendations</span>
-            </a>
-            {powerProfile && powerProfile.some((p) => p.delta < 0) && (
-              <a href="/gm/trade" className="flex items-center gap-2 text-[12px] text-slate-600 hover:text-slate-700">
-                <span className="font-semibold">Explore trade targets for power deficits</span>
-              </a>
-            )}
+          <div className="px-4 py-3">
+            <div className="flex flex-wrap gap-4">
+              {/* IL alert */}
+              {injuredPlayers.length > 0 ? (
+                <div className="flex-1 min-w-[200px]">
+                  <div className="text-[11px] text-red-600 font-semibold mb-2">{injuredPlayers.length} on IL</div>
+                  <div className="space-y-1">
+                    {injuredPlayers.map((p, i) => (
+                      <div key={i} className="flex items-center gap-2 text-[11px]">
+                        <span className="text-red-500 text-[10px] font-bold">IL</span>
+                        <span className="text-slate-700">{p.name}</span>
+                        <span className="text-slate-400">{p.pos}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <div className="flex-1 min-w-[200px]">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[13px] text-emerald-600 font-semibold">All healthy</span>
+                    <span className="text-[11px] text-slate-400">No players on IL</span>
+                  </div>
+                </div>
+              )}
+
+              {/* Quick links */}
+              <div className="flex-1 min-w-[200px] space-y-1.5">
+                <a href="/gm/bullpen" className="block text-[12px] text-slate-600 hover:text-slate-700 font-medium">
+                  Check pitching starts this week
+                </a>
+                <a href="/gm/free-agents" className="block text-[12px] text-slate-600 hover:text-slate-700 font-medium">
+                  Browse streaming targets
+                </a>
+                <a href="/gm/trade" className="block text-[12px] text-slate-600 hover:text-slate-700 font-medium">
+                  Explore trade opportunities
+                </a>
+                <a href="/league/schedule" className="block text-[12px] text-slate-600 hover:text-slate-700 font-medium">
+                  View remaining schedule
+                </a>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/web/src/app/gm/roster/page.tsx
+++ b/web/src/app/gm/roster/page.tsx
@@ -39,9 +39,11 @@ interface TeamSchedule {
 
 interface ZScorePlayer {
   name: string;
+  pos: string;
   zScores: Record<string, number>;
   zTotal: number;
   far: number;
+  onTeamId: number;
 }
 
 interface PlayerSeasonStats {
@@ -669,8 +671,128 @@ export default function RosterPage() {
         </div>
       )}
 
+      {/* Position Analysis */}
+      {resolvedTeam && allZScores.length > 0 && (
+        <PositionAnalysis
+          roster={resolvedTeam.roster}
+          zScoreMap={zScoreMap}
+          allZScores={allZScores}
+          myTeamId={resolvedTeam.id}
+        />
+      )}
+
       {/* GM Advisor */}
       <GmAdvisor />
     </div>
   );
 }
+
+const POS_SLOTS: { slot: string; slotIds: number[] }[] = [
+  { slot: "C", slotIds: [0] },
+  { slot: "1B", slotIds: [1] },
+  { slot: "2B", slotIds: [2] },
+  { slot: "3B", slotIds: [3] },
+  { slot: "SS", slotIds: [4] },
+  { slot: "OF", slotIds: [5, 6, 7] },
+  { slot: "UTIL", slotIds: [8, 12] },
+  { slot: "SP", slotIds: [14] },
+  { slot: "RP", slotIds: [15] },
+  { slot: "P", slotIds: [13] },
+];
+
+function PositionAnalysis({
+  roster,
+  zScoreMap,
+  allZScores,
+  myTeamId,
+}: {
+  roster: RosterPlayer[];
+  zScoreMap: Map<string, ZScorePlayer>;
+  allZScores: ZScorePlayer[];
+  myTeamId: number;
+}) {
+  const positionData = useMemo(() => {
+    return POS_SLOTS.map((ps) => {
+      const myPlayers = roster
+        .filter((p) => ps.slotIds.includes(p.slotId))
+        .map((p) => {
+          const zp = zScoreMap.get(p.name);
+          return { name: p.name, pos: p.pos, far: safeNum(zp?.far ?? 0), zTotal: safeNum(zp?.zTotal ?? 0) };
+        })
+        .sort((a, b) => b.far - a.far);
+
+      const bestFAs = allZScores
+        .filter((p) => {
+          if (p.onTeamId !== 0) return false;
+          if (ps.slot === "SP" || ps.slot === "RP" || ps.slot === "P") return p.pos === "SP" || p.pos === "RP";
+          return p.pos === ps.slot || (ps.slot === "OF" && p.pos === "OF") || ps.slot === "UTIL";
+        })
+        .sort((a, b) => b.far - a.far)
+        .slice(0, 2)
+        .map((p) => ({ name: p.name, pos: p.pos, far: safeNum(p.far), zTotal: safeNum(p.zTotal) }));
+
+      const myBestFar = myPlayers.length > 0 ? myPlayers[0].far : 0;
+      const faBestFar = bestFAs.length > 0 ? bestFAs[0].far : 0;
+      const hasUpgrade = faBestFar > myBestFar && myPlayers.length > 0;
+      const tierLabel = myBestFar >= 3 ? "Elite" : myBestFar >= 1.5 ? "Solid" : myBestFar >= 0 ? "Average" : "Weak";
+      const tierColor = myBestFar >= 3 ? "text-emerald-600" : myBestFar >= 1.5 ? "text-blue-600" : myBestFar >= 0 ? "text-slate-600" : "text-red-600";
+
+      return { slot: ps.slot, myPlayers, bestFAs, hasUpgrade, tierLabel, tierColor };
+    }).filter((p) => p.myPlayers.length > 0);
+  }, [roster, zScoreMap, allZScores]);
+
+  if (positionData.length === 0) return null;
+
+  return (
+    <div className="mt-6 rounded-lg border border-border bg-surface">
+      <div className="border-b border-border px-4 py-2 flex items-center justify-between">
+        <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-500">Position Analysis</span>
+        <span className="text-[9px] text-slate-400">Your player vs best available FA by position</span>
+      </div>
+      <div className="divide-y divide-border">
+        {positionData.map((pd) => (
+          <div key={pd.slot} className="px-4 py-2.5">
+            <div className="flex items-center justify-between mb-1">
+              <div className="flex items-center gap-2">
+                <span className="text-[12px] font-bold text-slate-700 w-8">{pd.slot}</span>
+                <span className={`text-[9px] font-bold uppercase ${pd.tierColor}`}>{pd.tierLabel}</span>
+              </div>
+              {pd.hasUpgrade && (
+                <span className="text-[9px] font-bold rounded px-1.5 py-0.5 bg-orange-100 text-orange-700">
+                  Upgrade Available
+                </span>
+              )}
+            </div>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <div>
+                <div className="text-[9px] text-slate-400 mb-0.5">Your roster</div>
+                {pd.myPlayers.map((p) => (
+                  <div key={p.name} className="flex items-center justify-between text-[11px]">
+                    <span className="text-slate-700">{p.name}</span>
+                    <span className={`font-mono tabular-nums ${p.far >= 2 ? "text-emerald-600" : p.far < 0 ? "text-red-600" : "text-slate-500"}`}>
+                      {p.far.toFixed(1)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+              {pd.bestFAs.length > 0 && (
+                <div>
+                  <div className="text-[9px] text-slate-400 mb-0.5">Best FA</div>
+                  {pd.bestFAs.map((p) => (
+                    <div key={p.name} className="flex items-center justify-between text-[11px]">
+                      <span className="text-blue-600">{p.name}</span>
+                      <span className={`font-mono tabular-nums ${p.far >= 2 ? "text-emerald-600" : "text-slate-500"}`}>
+                        {p.far.toFixed(1)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/web/src/app/gm/schedule-outlook/page.tsx
+++ b/web/src/app/gm/schedule-outlook/page.tsx
@@ -1,0 +1,451 @@
+"use client";
+
+import { useState, useEffect, useMemo, useRef } from "react";
+import { mean, stddev } from "@/lib/z-scores";
+import { CATEGORY_WEIGHTS } from "@/lib/category-weights";
+import { EspnAuthRequired } from "@/components/EspnAuthRequired";
+import { sanitizeNum, safeDivide } from "@/lib/sanitize";
+
+interface MatchupWeek {
+  period: number;
+  startDate: string;
+  endDate: string;
+  isCurrent: boolean;
+  myOpponentId: number | null;
+  myOpponentName: string | null;
+}
+
+interface ScheduleData {
+  myTeamId: number;
+  currentMatchupPeriod: number;
+  seasonStart: string;
+  weeks: MatchupWeek[];
+}
+
+interface StandingsTeam {
+  teamId: number;
+  teamName: string;
+  wins: number;
+  losses: number;
+  ties: number;
+  pct: number;
+  gamesBack: number;
+  rank: number;
+  playoffSeed: number;
+}
+
+interface StandingsData {
+  currentMatchupPeriod: number;
+  totalMatchupPeriods: number;
+  myTeamId: number;
+  teams: StandingsTeam[];
+}
+
+interface LeagueTeam {
+  teamId: number;
+  teamName: string;
+  categories: Record<string, number>;
+  ranks: Record<string, number>;
+  powerRank: number;
+  compositeAvgRank: number;
+}
+
+interface LeagueStatsData {
+  myTeamId: number;
+  teams: LeagueTeam[];
+  averages: Record<string, number>;
+}
+
+const CATS = ["H", "R", "HR", "TB", "RBI", "BB", "SB", "AVG", "K", "QS", "W", "L", "SV", "HD", "ERA", "WHIP"] as const;
+const LOWER_IS_BETTER_CATS = new Set(["ERA", "WHIP", "L"]);
+const PLAYOFF_CUTOFF = 6;
+
+function computeMatchupDifficulty(
+  myZ: Record<string, number>,
+  oppZ: Record<string, number>,
+): number {
+  const diffs = CATS.map((cat) => ({
+    diff: (oppZ[cat] ?? 0) - (myZ[cat] ?? 0),
+    weight: CATEGORY_WEIGHTS[cat] ?? 0,
+  }));
+  const totalWeight = diffs.reduce((s, d) => s + d.weight, 0);
+  if (totalWeight === 0) return 0;
+  return diffs.reduce((s, d) => s + d.diff * d.weight, 0) / totalWeight;
+}
+
+function buildZScoreMap(
+  teams: Array<{ teamId: number; categories: Record<string, number> }>,
+  averages: Record<string, number>,
+): Record<number, Record<string, number>> {
+  const zMap: Record<number, Record<string, number>> = {};
+  for (const cat of CATS) {
+    const vals = teams.map((t) => t.categories[cat] ?? 0);
+    const mu = averages[cat] ?? mean(vals);
+    const sd = stddev(vals, mu);
+    for (const team of teams) {
+      if (!zMap[team.teamId]) zMap[team.teamId] = {};
+      const raw = sd > 0 ? ((team.categories[cat] ?? 0) - mu) / sd : 0;
+      zMap[team.teamId][cat] = LOWER_IS_BETTER_CATS.has(cat) ? -raw : raw;
+    }
+  }
+  return zMap;
+}
+
+function difficultyStyle(score: number): { label: string; bg: string; text: string; border: string } {
+  if (score < -0.3) return { label: "Easy", bg: "bg-emerald-50", text: "text-emerald-700", border: "border-emerald-200" };
+  if (score < -0.1) return { label: "Favorable", bg: "bg-emerald-50/50", text: "text-emerald-600", border: "border-emerald-200/50" };
+  if (score > 0.3) return { label: "Hard", bg: "bg-red-50", text: "text-red-700", border: "border-red-200" };
+  if (score > 0.1) return { label: "Tough", bg: "bg-orange-50", text: "text-orange-700", border: "border-orange-200" };
+  return { label: "Even", bg: "bg-slate-50", text: "text-slate-600", border: "border-slate-200" };
+}
+
+function fmtDateRange(start: string, end: string): string {
+  const s = new Date(start + "T12:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  const e = new Date(end + "T12:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  return `${s} – ${e}`;
+}
+
+export default function ScheduleOutlookPage() {
+  const [schedule, setSchedule] = useState<ScheduleData | null>(null);
+  const [standings, setStandings] = useState<StandingsData | null>(null);
+  const [leagueStats, setLeagueStats] = useState<LeagueStatsData | null>(null);
+  const [h2hMatchups, setH2hMatchups] = useState<Record<number, { myWins: number; myLosses: number; myTies: number }>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const currentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    Promise.all([
+      fetch("/api/espn/schedule").then((r) => r.json()),
+      fetch("/api/espn/standings").then((r) => r.json()).catch(() => null),
+      fetch("/api/espn/league-stats?scope=season").then((r) => r.json()).catch(() => null),
+      fetch("/api/espn/h2h").then((r) => r.json()).catch(() => null),
+    ]).then(([schedData, standData, lsData, h2hData]) => {
+      if (schedData.error) { setError(schedData.error); return; }
+      setSchedule(schedData);
+      if (standData && !standData.error) setStandings(standData);
+      if (lsData && !lsData.error) setLeagueStats(lsData);
+      if (h2hData?.matchups) {
+        const byWeek: Record<number, { myWins: number; myLosses: number; myTies: number }> = {};
+        for (const m of h2hData.matchups) {
+          byWeek[m.week] = { myWins: m.myWins, myLosses: m.myLosses, myTies: m.myTies };
+        }
+        setH2hMatchups(byWeek);
+      }
+    })
+    .catch(() => setError("FETCH_FAILED"))
+    .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (schedule && currentRef.current) {
+      currentRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [schedule]);
+
+  const zScoreMap = useMemo(() => {
+    if (!leagueStats?.teams || !leagueStats?.averages) return {};
+    return buildZScoreMap(leagueStats.teams, leagueStats.averages);
+  }, [leagueStats]);
+
+  const teamRanks = useMemo(() => {
+    if (!leagueStats?.teams) return {} as Record<number, LeagueTeam>;
+    const map: Record<number, LeagueTeam> = {};
+    for (const t of leagueStats.teams) map[t.teamId] = t;
+    return map;
+  }, [leagueStats]);
+
+  const standingsMap = useMemo(() => {
+    if (!standings?.teams) return {} as Record<number, StandingsTeam>;
+    const map: Record<number, StandingsTeam> = {};
+    for (const t of standings.teams) map[t.teamId] = t;
+    return map;
+  }, [standings]);
+
+  const myStanding = useMemo(() => {
+    if (!standings || !schedule) return null;
+    return standings.teams.find((t) => t.teamId === schedule.myTeamId) ?? null;
+  }, [standings, schedule]);
+
+  const futureWeeks = useMemo(() => {
+    if (!schedule) return [];
+    return schedule.weeks.filter((w) => w.period >= schedule.currentMatchupPeriod);
+  }, [schedule]);
+
+  const weekDifficulties = useMemo(() => {
+    if (!schedule || !leagueStats) return new Map<number, number>();
+    const myZ = zScoreMap[schedule.myTeamId];
+    if (!myZ) return new Map<number, number>();
+    const map = new Map<number, number>();
+    for (const week of schedule.weeks) {
+      if (week.myOpponentId == null) continue;
+      const oppZ = zScoreMap[week.myOpponentId];
+      if (!oppZ) continue;
+      map.set(week.period, computeMatchupDifficulty(myZ, oppZ));
+    }
+    return map;
+  }, [schedule, leagueStats, zScoreMap]);
+
+  const playoffMath = useMemo(() => {
+    if (!myStanding || !standings || !schedule) return null;
+    const totalWeeks = schedule.weeks.length;
+    const weeksLeft = totalWeeks - schedule.currentMatchupPeriod + 1;
+    const catsPerWeek = 16;
+    const myWins = myStanding.wins;
+    const myLosses = myStanding.losses;
+    const myTies = myStanding.ties;
+
+    const sorted = [...standings.teams].sort((a, b) => {
+      const pctA = safeDivide(a.wins, a.wins + a.losses + a.ties);
+      const pctB = safeDivide(b.wins, b.wins + b.losses + b.ties);
+      return pctB - pctA;
+    });
+
+    const myRank = sorted.findIndex((t) => t.teamId === schedule.myTeamId) + 1;
+    const playoffLine = sorted[PLAYOFF_CUTOFF - 1];
+    const playoffWins = playoffLine ? playoffLine.wins : 0;
+    const playoffGap = playoffWins - myWins;
+
+    const winsPerWeekNeeded = weeksLeft > 0 ? Math.max(0, Math.ceil(playoffGap / weeksLeft)) : 0;
+    const magicNumber = weeksLeft > 0 ? Math.max(0, playoffGap + 1) : 0;
+
+    const positionTargets = sorted.slice(0, Math.min(6, sorted.length)).map((t, idx) => ({
+      rank: idx + 1,
+      teamName: t.teamName,
+      wins: t.wins,
+      gap: t.wins - myWins,
+      winsNeeded: weeksLeft > 0 ? Math.max(0, Math.ceil((t.wins - myWins) / weeksLeft)) : 0,
+    }));
+
+    return {
+      myRank,
+      myWins,
+      myLosses,
+      myTies,
+      weeksLeft,
+      catsPerWeek,
+      playoffGap,
+      winsPerWeekNeeded,
+      magicNumber,
+      positionTargets,
+      inPlayoffs: myRank <= PLAYOFF_CUTOFF,
+    };
+  }, [myStanding, standings, schedule]);
+
+  if (loading) return <div className="flex h-64 items-center justify-center text-slate-500">Loading schedule...</div>;
+  if (error === "ESPN_CREDS_MISSING" || error === "MY_ESPN_TEAM_ID_MISSING") {
+    return <div className="flex min-h-[70vh] items-center justify-center px-4"><EspnAuthRequired /></div>;
+  }
+  if (error || !schedule) {
+    return (
+      <div className="flex h-64 flex-col items-center justify-center gap-2">
+        <div className="text-red-600">Failed to load schedule</div>
+        <div className="text-[12px] text-slate-500">{error}</div>
+      </div>
+    );
+  }
+
+  const totalWeeks = schedule.weeks.length;
+  const pastWeeks = schedule.weeks.filter((w) => w.period < schedule.currentMatchupPeriod);
+  const pastRecord = pastWeeks.reduce(
+    (acc, w) => {
+      const r = h2hMatchups[w.period];
+      if (!r) return acc;
+      return { w: acc.w + r.myWins, l: acc.l + r.myLosses, t: acc.t + r.myTies };
+    },
+    { w: 0, l: 0, t: 0 }
+  );
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-6">
+      <div className="mb-5">
+        <h1 className="text-lg font-bold text-gray-900">Season Timeline</h1>
+        <span className="text-[12px] text-slate-500">
+          Week {schedule.currentMatchupPeriod} of {totalWeeks} · {totalWeeks - pastWeeks.length} weeks remaining
+        </span>
+      </div>
+
+      {/* Playoff Math */}
+      {playoffMath && (
+        <div className="mb-5 rounded-lg border border-border bg-surface">
+          <div className="border-b border-border px-4 py-2 flex items-center justify-between">
+            <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-500">Playoff Math</span>
+            <span className={`text-[11px] font-bold ${playoffMath.inPlayoffs ? "text-emerald-600" : "text-red-600"}`}>
+              {playoffMath.inPlayoffs ? `In playoff position (#${playoffMath.myRank})` : `Outside playoffs (#${playoffMath.myRank})`}
+            </span>
+          </div>
+          <div className="px-4 py-4">
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-4">
+              <div className="text-center">
+                <div className="text-[10px] text-slate-500">Current Rank</div>
+                <div className={`text-2xl font-bold tabular-nums ${playoffMath.myRank <= PLAYOFF_CUTOFF ? "text-emerald-600" : "text-red-600"}`}>
+                  #{playoffMath.myRank}
+                </div>
+              </div>
+              <div className="text-center">
+                <div className="text-[10px] text-slate-500">Record</div>
+                <div className="text-2xl font-bold tabular-nums text-slate-700">
+                  {playoffMath.myWins}-{playoffMath.myLosses}{playoffMath.myTies > 0 ? `-${playoffMath.myTies}` : ""}
+                </div>
+              </div>
+              <div className="text-center">
+                <div className="text-[10px] text-slate-500">Weeks Left</div>
+                <div className="text-2xl font-bold tabular-nums text-slate-700">{playoffMath.weeksLeft}</div>
+              </div>
+              <div className="text-center">
+                <div className="text-[10px] text-slate-500">Cat Wins to Playoff</div>
+                <div className={`text-2xl font-bold tabular-nums ${playoffMath.playoffGap <= 0 ? "text-emerald-600" : "text-orange-600"}`}>
+                  {playoffMath.playoffGap <= 0 ? "On pace" : `+${playoffMath.playoffGap}`}
+                </div>
+              </div>
+            </div>
+
+            {/* Position targets */}
+            {playoffMath.positionTargets.length > 0 && (
+              <div className="border-t border-border pt-3">
+                <div className="text-[10px] font-semibold uppercase tracking-wider text-slate-500 mb-2">
+                  Wins needed per week to reach each position
+                </div>
+                <div className="grid grid-cols-3 sm:grid-cols-6 gap-2">
+                  {playoffMath.positionTargets.map((t) => {
+                    const isMe = t.gap === 0;
+                    const isPlayoff = t.rank <= PLAYOFF_CUTOFF;
+                    return (
+                      <div key={t.rank} className={`rounded border p-2 text-center ${
+                        isMe ? "border-orange-300 bg-orange-50" :
+                        isPlayoff ? "border-emerald-200 bg-emerald-50/50" : "border-border"
+                      }`}>
+                        <div className="text-[9px] text-slate-500">#{t.rank}</div>
+                        <div className="text-[10px] font-medium text-slate-700 truncate">{t.teamName}</div>
+                        <div className={`text-[14px] font-bold tabular-nums ${
+                          t.gap <= 0 ? "text-emerald-600" : t.gap <= 5 ? "text-orange-600" : "text-red-600"
+                        }`}>
+                          {t.gap <= 0 ? "Ahead" : `${t.winsNeeded}/wk`}
+                        </div>
+                        <div className="text-[9px] text-slate-400">{t.wins}W ({t.gap > 0 ? `+${t.gap}` : t.gap} gap)</div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Remaining Schedule Difficulty */}
+      {futureWeeks.length > 0 && (
+        <div className="mb-5 rounded-lg border border-border bg-surface">
+          <div className="border-b border-border px-4 py-2">
+            <span className="text-[10px] font-semibold uppercase tracking-widest text-slate-500">Remaining Schedule Strength</span>
+          </div>
+          <div className="px-4 py-3">
+            <div className="flex flex-wrap gap-1">
+              {futureWeeks.map((week) => {
+                const diff = weekDifficulties.get(week.period) ?? 0;
+                const style = difficultyStyle(diff);
+                const oppTeam = week.myOpponentId ? teamRanks[week.myOpponentId] : null;
+                const oppStanding = week.myOpponentId ? standingsMap[week.myOpponentId] : null;
+                return (
+                  <div key={week.period}
+                    className={`rounded border px-2.5 py-2 text-center min-w-[72px] ${style.bg} ${style.border} ${week.isCurrent ? "ring-2 ring-orange-400" : ""}`}
+                    title={`Week ${week.period}: ${week.myOpponentName ?? "TBD"}`}
+                  >
+                    <div className="text-[9px] text-slate-500">Wk {week.period}</div>
+                    <div className={`text-[10px] font-bold ${style.text}`}>{style.label}</div>
+                    {oppTeam && (
+                      <div className="text-[9px] text-slate-400">#{oppTeam.powerRank}</div>
+                    )}
+                    {oppStanding && (
+                      <div className="text-[8px] text-slate-400 tabular-nums">
+                        {oppStanding.wins}-{oppStanding.losses}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Summary */}
+            {(() => {
+              const easy = futureWeeks.filter((w) => (weekDifficulties.get(w.period) ?? 0) < -0.1).length;
+              const hard = futureWeeks.filter((w) => (weekDifficulties.get(w.period) ?? 0) > 0.1).length;
+              const even = futureWeeks.length - easy - hard;
+              return (
+                <div className="mt-3 flex items-center gap-4 text-[11px]">
+                  <span className="text-emerald-600 font-semibold">{easy} favorable</span>
+                  <span className="text-slate-500">{even} even</span>
+                  <span className="text-red-600 font-semibold">{hard} tough</span>
+                </div>
+              );
+            })()}
+          </div>
+        </div>
+      )}
+
+      {/* Full Schedule Timeline */}
+      <div className="space-y-1">
+        {schedule.weeks.map((week) => {
+          const isPast = week.period < schedule.currentMatchupPeriod;
+          const isCurrent = week.isCurrent;
+          const matchupResult = isPast ? h2hMatchups[week.period] : null;
+          const diff = weekDifficulties.get(week.period) ?? 0;
+          const style = difficultyStyle(diff);
+          const oppTeam = week.myOpponentId ? teamRanks[week.myOpponentId] : null;
+
+          return (
+            <div key={week.period} ref={isCurrent ? currentRef : undefined}
+              className={`rounded-lg border px-4 py-3 flex items-center justify-between ${
+                isCurrent ? "border-orange-300 bg-orange-50" :
+                isPast ? "border-border bg-surface/50 opacity-80" : "border-border bg-surface"
+              }`}
+            >
+              <div className="flex items-center gap-4">
+                <span className={`text-[13px] font-bold tabular-nums w-16 ${
+                  isCurrent ? "text-orange-600" : "text-slate-500"
+                }`}>
+                  Week {week.period}
+                </span>
+                <span className={`text-[12px] ${isCurrent ? "text-orange-700" : "text-slate-600"}`}>
+                  {fmtDateRange(week.startDate, week.endDate)}
+                </span>
+              </div>
+              <div className="flex items-center gap-3">
+                {week.myOpponentName ? (
+                  <>
+                    <span className={`text-[13px] font-medium ${isCurrent ? "text-orange-700" : "text-slate-700"}`}>
+                      vs {week.myOpponentName}
+                    </span>
+                    {matchupResult && (
+                      <span className={`text-[12px] font-bold font-mono tabular-nums ${
+                        matchupResult.myWins > matchupResult.myLosses ? "text-emerald-600" :
+                        matchupResult.myLosses > matchupResult.myWins ? "text-red-600" : "text-orange-600"
+                      }`}>
+                        {matchupResult.myWins}-{matchupResult.myLosses}{matchupResult.myTies > 0 ? `-${matchupResult.myTies}` : ""}
+                      </span>
+                    )}
+                    {!isPast && oppTeam && (
+                      <span className="text-[9px] font-bold text-slate-400">#{oppTeam.powerRank}</span>
+                    )}
+                    {!isPast && (
+                      <span className={`text-[9px] font-bold border rounded px-1.5 py-0.5 ${style.bg} ${style.text} ${style.border}`}>
+                        {style.label}
+                      </span>
+                    )}
+                  </>
+                ) : (
+                  <span className="text-[12px] text-slate-400">TBD</span>
+                )}
+                {isCurrent && (
+                  <span className="text-[9px] font-bold uppercase text-orange-600 border border-orange-300 rounded px-1.5 py-0.5">
+                    NOW
+                  </span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/gm/trade/page.tsx
+++ b/web/src/app/gm/trade/page.tsx
@@ -66,6 +66,12 @@ interface StandingsTeam {
   rank: number;
 }
 
+interface LiveTeam {
+  teamId: number;
+  teamName: string;
+  ranks: Record<string, number>;
+}
+
 interface TradeTarget {
   player: ZScorePlayer;
   teamName: string;
@@ -98,6 +104,7 @@ export default function TradeRoomPage() {
   const [zScorePlayers, setZScorePlayers] = useState<ZScorePlayer[]>([]);
   const [standings, setStandings] = useState<StandingsTeam[]>([]);
   const [myTeamId, setMyTeamId] = useState<number | null>(null);
+  const [liveTeams, setLiveTeams] = useState<LiveTeam[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -116,13 +123,15 @@ export default function TradeRoomPage() {
       fetch("/api/espn/matchup").then((r) => r.json()).catch(() => ({})),
       fetch("/api/analysis/z-scores").then((r) => r.json()).catch(() => ({ players: [] })),
       fetch("/api/espn/standings").then((r) => r.json()).catch(() => ({ teams: [] })),
-    ]).then(([rosterData, statsData, matchupData, zData, standingsData]) => {
+      fetch("/api/espn/league-stats?scope=season").then((r) => r.json()).catch(() => ({ teams: [] })),
+    ]).then(([rosterData, statsData, matchupData, zData, standingsData, leagueData]) => {
       if (rosterData.error) { setError(rosterData.error); return; }
       setTeams(rosterData);
       if (statsData.players) setPlayerStats(statsData.players);
       if (matchupData.myTeamId) setMyTeamId(matchupData.myTeamId);
       setZScorePlayers(zData.players ?? []);
       setStandings(standingsData.teams ?? []);
+      if (leagueData.teams) setLiveTeams(leagueData.teams);
     })
     .catch(() => setError("FETCH_FAILED"))
     .finally(() => setLoading(false));
@@ -605,6 +614,91 @@ export default function TradeRoomPage() {
                 )}
               </div>
             ))}
+          </div>
+        </div>
+      )}
+
+      {/* Buyer/Seller Board */}
+      {standings.length > 0 && (
+        <div className="mb-4 rounded-lg border border-slate-300 bg-surface">
+          <div className="border-b border-border px-4 py-2.5">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-600">Buyer/Seller Board</span>
+            <span className="ml-2 text-[10px] text-slate-400">Teams classified by standings and roster activity</span>
+          </div>
+          <div className="grid gap-0 sm:grid-cols-2">
+            {/* Sellers */}
+            <div className="border-r border-border">
+              <div className="px-3 py-2 border-b border-border bg-red-50/50">
+                <span className="text-[10px] font-semibold uppercase tracking-wider text-red-600">Sellers</span>
+                <span className="ml-1 text-[10px] text-slate-400">(bottom half, potential trade targets)</span>
+              </div>
+              <div className="divide-y divide-border">
+                {standings.filter((t) => t.rank > Math.ceil(standings.length / 2) && t.teamId !== myTeamId)
+                  .sort((a, b) => b.rank - a.rank)
+                  .map((t) => {
+                    const roster = teams.find((r) => r.id === t.teamId);
+                    const topPlayers = zScorePlayers
+                      .filter((p) => p.onTeamId === t.teamId && p.far >= 2.0)
+                      .sort((a, b) => b.far - a.far)
+                      .slice(0, 3);
+                    return (
+                      <div key={t.teamId} className="px-3 py-2">
+                        <div className="flex items-center justify-between">
+                          <span className="text-[12px] font-medium text-slate-700">{t.teamName}</span>
+                          <span className="text-[11px] font-mono tabular-nums text-slate-500">
+                            {t.wins}-{t.losses} (#{t.rank})
+                          </span>
+                        </div>
+                        {topPlayers.length > 0 && (
+                          <div className="mt-1 flex flex-wrap gap-1">
+                            {topPlayers.map((p) => (
+                              <span key={p.name} className="text-[9px] rounded bg-slate-100 px-1.5 py-0.5 text-slate-600">
+                                {p.name} <span className="text-emerald-600">FAR {p.far.toFixed(1)}</span>
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+              </div>
+            </div>
+            {/* Buyers */}
+            <div>
+              <div className="px-3 py-2 border-b border-border bg-emerald-50/50">
+                <span className="text-[10px] font-semibold uppercase tracking-wider text-emerald-600">Buyers</span>
+                <span className="ml-1 text-[10px] text-slate-400">(top half, competing for assets)</span>
+              </div>
+              <div className="divide-y divide-border">
+                {standings.filter((t) => t.rank <= Math.ceil(standings.length / 2) && t.teamId !== myTeamId)
+                  .sort((a, b) => a.rank - b.rank)
+                  .map((t) => {
+                    const weakCats = (() => {
+                      const lt = liveTeams.find((lt: LiveTeam) => lt.teamId === t.teamId);
+                      if (!lt) return [];
+                      return Object.entries(lt.ranks)
+                        .filter(([, r]) => r >= 8)
+                        .map(([cat]) => cat)
+                        .slice(0, 3);
+                    })();
+                    return (
+                      <div key={t.teamId} className="px-3 py-2">
+                        <div className="flex items-center justify-between">
+                          <span className="text-[12px] font-medium text-slate-700">{t.teamName}</span>
+                          <span className="text-[11px] font-mono tabular-nums text-slate-500">
+                            {t.wins}-{t.losses} (#{t.rank})
+                          </span>
+                        </div>
+                        {weakCats.length > 0 && (
+                          <div className="mt-1 text-[10px] text-slate-500">
+                            Needs: <span className="text-red-600">{weakCats.join(", ")}</span>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+              </div>
+            </div>
           </div>
         </div>
       )}

--- a/web/src/app/scouting/page.tsx
+++ b/web/src/app/scouting/page.tsx
@@ -189,12 +189,54 @@ function generateDraftStyle(
   return `${s1} ${s2}`;
 }
 
+interface LiveTeam {
+  teamId: number;
+  teamName: string;
+  categories: Record<string, number>;
+  ranks: Record<string, number>;
+  powerRank: number;
+}
+
+interface LiveStandingsTeam {
+  teamId: number;
+  teamName: string;
+  wins: number;
+  losses: number;
+  ties: number;
+  rank: number;
+}
+
+interface LiveRosterPlayer {
+  name: string;
+  pos: string;
+  acquisitionType: string;
+}
+
+interface LiveRosterTeam {
+  id: number;
+  name: string;
+  roster: LiveRosterPlayer[];
+}
+
+interface H2hMatchup {
+  week: number;
+  myWins: number;
+  myLosses: number;
+  myTies: number;
+  oppTeamId: number;
+}
+
 export default function ScoutingPage() {
   const [profiles, setProfiles] = useState<DraftProfile[]>([]);
   const [allStandings, setAllStandings] = useState<StandingsRow[]>([]);
   const [allPicks, setAllPicks] = useState<DraftPick[]>([]);
   const [posMap, setPosMap] = useState<Record<string, string>>({});
   const [selectedTeam, setSelectedTeam] = useState<string>("");
+  const [liveTeams, setLiveTeams] = useState<LiveTeam[]>([]);
+  const [liveStandings, setLiveStandings] = useState<LiveStandingsTeam[]>([]);
+  const [liveRosters, setLiveRosters] = useState<LiveRosterTeam[]>([]);
+  const [h2hData, setH2hData] = useState<H2hMatchup[]>([]);
+  const [myTeamId, setMyTeamId] = useState<number | null>(null);
 
   useEffect(() => {
     fetch("/api/profiles").then((r) => r.json()).then((data: DraftProfile[]) => {
@@ -204,6 +246,18 @@ export default function ScoutingPage() {
     fetch("/api/standings").then((r) => r.json()).then(setAllStandings);
     fetch("/api/draft-results").then((r) => r.json()).then(setAllPicks);
     fetch("/api/player-positions").then((r) => r.json()).then(setPosMap);
+    fetch("/api/espn/league-stats?scope=season").then((r) => r.json()).then((d) => {
+      if (!d.error && d.teams) { setLiveTeams(d.teams); setMyTeamId(d.myTeamId); }
+    }).catch(() => {});
+    fetch("/api/espn/standings").then((r) => r.json()).then((d) => {
+      if (!d.error && d.teams) setLiveStandings(d.teams);
+    }).catch(() => {});
+    fetch("/api/espn/roster").then((r) => r.json()).then((d) => {
+      if (!d.error && Array.isArray(d)) setLiveRosters(d);
+    }).catch(() => {});
+    fetch("/api/espn/h2h").then((r) => r.json()).then((d) => {
+      if (d?.matchups) setH2hData(d.matchups);
+    }).catch(() => {});
   }, []);
 
   const selected = useMemo(() => profiles.find((p) => p.team === selectedTeam), [profiles, selectedTeam]);
@@ -342,6 +396,99 @@ export default function ScoutingPage() {
             ))}
           </div>
         </div>
+
+        {/* ── Current Season Profile (Live ESPN Data) ── */}
+        {(() => {
+          const liveTeam = liveTeams.find((t) => teamNamesSet.has(t.teamName));
+          const liveStanding = liveStandings.find((t) => teamNamesSet.has(t.teamName));
+          const liveRoster = liveRosters.find((t) => teamNamesSet.has(t.name));
+          if (!liveTeam && !liveStanding) return null;
+
+          const strongCats = liveTeam ? CAT_KEYS.filter((c) => (liveTeam.ranks[c] ?? 10) <= 3) : [];
+          const weakCats = liveTeam ? CAT_KEYS.filter((c) => (liveTeam.ranks[c] ?? 0) >= 8) : [];
+
+          const recentAdds = liveRoster?.roster.filter((p) => p.acquisitionType === "ADD").length ?? 0;
+          const isActive = recentAdds >= 5;
+
+          const myH2h = h2hData.filter((m) => {
+            if (!liveTeam || !myTeamId) return false;
+            return m.oppTeamId === liveTeam.teamId;
+          });
+          const h2hRecord = myH2h.reduce(
+            (acc, m) => ({ w: acc.w + m.myWins, l: acc.l + m.myLosses, t: acc.t + m.myTies }),
+            { w: 0, l: 0, t: 0 }
+          );
+
+          return (
+            <div className="rounded-lg border border-orange-300 bg-surface">
+              <div className="border-b border-orange-300 px-4 py-2 flex items-center justify-between">
+                <span className="text-[10px] font-semibold uppercase tracking-widest text-orange-600">Current Season</span>
+                {liveStanding && (
+                  <span className="text-[12px] font-bold tabular-nums text-slate-700">
+                    {liveStanding.wins}-{liveStanding.losses}{liveStanding.ties > 0 ? `-${liveStanding.ties}` : ""} (#{liveStanding.rank})
+                  </span>
+                )}
+              </div>
+              <div className="px-4 py-4 space-y-3">
+                {/* Strengths/Weaknesses */}
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div>
+                    <div className="text-[10px] font-semibold uppercase tracking-wider text-emerald-600 mb-1">Strong (Top 3)</div>
+                    <div className="flex flex-wrap gap-1">
+                      {strongCats.length > 0 ? strongCats.map((c) => (
+                        <span key={c} className="rounded bg-emerald-50 border border-emerald-200 px-2 py-0.5 text-[10px] font-bold text-emerald-700">
+                          {c} #{liveTeam!.ranks[c]}
+                        </span>
+                      )) : <span className="text-[11px] text-slate-400">None</span>}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-[10px] font-semibold uppercase tracking-wider text-red-600 mb-1">Weak (Bottom 3)</div>
+                    <div className="flex flex-wrap gap-1">
+                      {weakCats.length > 0 ? weakCats.map((c) => (
+                        <span key={c} className="rounded bg-red-50 border border-red-200 px-2 py-0.5 text-[10px] font-bold text-red-600">
+                          {c} #{liveTeam!.ranks[c]}
+                        </span>
+                      )) : <span className="text-[11px] text-slate-400">None</span>}
+                    </div>
+                  </div>
+                </div>
+
+                {/* Trading tendency */}
+                <div className="flex items-center gap-4 text-[11px]">
+                  <span className="text-slate-500">Roster activity:</span>
+                  <span className={`font-bold ${isActive ? "text-orange-600" : "text-slate-500"}`}>
+                    {recentAdds} FA adds
+                  </span>
+                  <span className={`text-[9px] font-bold rounded px-1.5 py-0.5 ${
+                    isActive ? "bg-orange-100 text-orange-700" : "bg-slate-100 text-slate-600"
+                  }`}>
+                    {isActive ? "Active" : "Quiet"}
+                  </span>
+                  {liveStanding && liveStanding.rank >= 8 && isActive && (
+                    <span className="text-[9px] font-bold rounded px-1.5 py-0.5 bg-purple-100 text-purple-700">Buyer</span>
+                  )}
+                  {liveStanding && liveStanding.rank >= 8 && !isActive && (
+                    <span className="text-[9px] font-bold rounded px-1.5 py-0.5 bg-red-100 text-red-700">Seller</span>
+                  )}
+                </div>
+
+                {/* H2H record vs this team */}
+                {myTeamId && (h2hRecord.w > 0 || h2hRecord.l > 0) && (
+                  <div className="flex items-center gap-3 text-[11px]">
+                    <span className="text-slate-500">Your H2H record:</span>
+                    <span className={`font-bold tabular-nums ${
+                      h2hRecord.w > h2hRecord.l ? "text-emerald-600" :
+                      h2hRecord.l > h2hRecord.w ? "text-red-600" : "text-slate-600"
+                    }`}>
+                      {h2hRecord.w}-{h2hRecord.l}{h2hRecord.t > 0 ? `-${h2hRecord.t}` : ""} cat wins
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })()}
 
         {/* ── Draft DNA + Recent Picks ── */}
         <div className="grid gap-4 lg:grid-cols-2">

--- a/web/src/app/strategy/page.tsx
+++ b/web/src/app/strategy/page.tsx
@@ -51,15 +51,41 @@ function urgencyColor(round: number) {
 
 const POSITIONS = ["C", "1B", "2B", "3B", "SS", "OF", "SP", "RP"] as const;
 
+interface DraftResult {
+  year: number;
+  round: number;
+  pick: number;
+  team: string;
+  playerName: string;
+  keeper: boolean;
+}
+
+interface ZScorePlayer {
+  name: string;
+  pos: string;
+  proTeam: string;
+  zTotal: number;
+  far: number;
+  onTeamId: number;
+}
+
+function safeNum(val: number): number {
+  return Number.isFinite(val) ? val : 0;
+}
+
 export default function StrategyPage() {
   const [players, setPlayers] = useState<Player[]>([]);
   const [profiles, setProfiles] = useState<DraftProfile[]>([]);
   const [espnData, setEspnData] = useState<Record<string, { adp: number | null; primaryPos: string | null }>>({});
+  const [draftResults, setDraftResults] = useState<DraftResult[]>([]);
+  const [zScorePlayers, setZScorePlayers] = useState<ZScorePlayer[]>([]);
 
   useEffect(() => {
     fetch("/api/rankings").then((r) => r.json()).then(setPlayers);
     fetch("/api/profiles").then((r) => r.json()).then(setProfiles);
     fetch("/api/espn-adp").then((r) => r.json()).then((d) => { if (!d.error) setEspnData(d); });
+    fetch("/api/draft-results").then((r) => r.json()).then((d) => { if (Array.isArray(d)) setDraftResults(d); }).catch(() => {});
+    fetch("/api/analysis/z-scores").then((r) => r.json()).then((d) => { if (d.players) setZScorePlayers(d.players); }).catch(() => {});
   }, []);
 
   // Deduplicate
@@ -405,6 +431,125 @@ export default function StrategyPage() {
 
         </div>
       </div>
+
+      {/* ── Draft Grade (Post-Draft) ── */}
+      {(() => {
+        const currentYear = new Date().getFullYear();
+        const myDraftPicks = draftResults.filter((p) => p.year === currentYear && p.team === MY_NAME);
+        if (myDraftPicks.length === 0 || zScorePlayers.length === 0) return null;
+
+        const zByName = new Map<string, ZScorePlayer>();
+        for (const z of zScorePlayers) zByName.set(z.name, z);
+
+        const graded = myDraftPicks
+          .sort((a, b) => a.round - b.round)
+          .map((pick) => {
+            const zp = zByName.get(pick.playerName);
+            const adpEntry = espnData[pick.playerName];
+            const adp = adpEntry?.adp;
+            const overallPick = pick.pick;
+            const farValue = zp ? safeNum(zp.far) : 0;
+            const adpDiff = adp != null ? Math.round(adp - overallPick) : null;
+            let grade: string;
+            let gradeColor: string;
+            if (farValue >= 5) { grade = "A+"; gradeColor = "text-emerald-600"; }
+            else if (farValue >= 3) { grade = "A"; gradeColor = "text-emerald-600"; }
+            else if (farValue >= 1.5) { grade = "B"; gradeColor = "text-blue-600"; }
+            else if (farValue >= 0.5) { grade = "C"; gradeColor = "text-slate-600"; }
+            else if (farValue >= -0.5) { grade = "D"; gradeColor = "text-orange-600"; }
+            else { grade = "F"; gradeColor = "text-red-600"; }
+
+            const isSteal = adpDiff !== null && adpDiff > 15;
+            const isBust = farValue < -0.5 && pick.round <= 10;
+
+            return { ...pick, zp, adp, adpDiff, farValue, grade, gradeColor, isSteal, isBust };
+          });
+
+        const steals = graded.filter((p) => p.isSteal);
+        const busts = graded.filter((p) => p.isBust);
+
+        return (
+          <div className="mt-6 space-y-4">
+            <h2 className="text-lg font-bold text-gray-900">Draft Grade ({currentYear})</h2>
+
+            {/* Steals and Busts */}
+            {(steals.length > 0 || busts.length > 0) && (
+              <div className="grid gap-4 sm:grid-cols-2">
+                {steals.length > 0 && (
+                  <div className="rounded-lg border border-emerald-300 bg-emerald-50/50 px-4 py-3">
+                    <div className="text-[10px] font-semibold uppercase tracking-wider text-emerald-700 mb-2">Steals</div>
+                    {steals.map((p) => (
+                      <div key={p.playerName} className="flex items-center justify-between py-1 border-b border-emerald-200/50 last:border-0">
+                        <div>
+                          <span className="text-[12px] font-medium text-slate-700">{p.playerName}</span>
+                          <span className="text-[10px] text-slate-500 ml-1">Rd {p.round}</span>
+                        </div>
+                        <div className="text-right">
+                          <span className="text-[10px] font-mono text-emerald-600">ADP +{p.adpDiff}</span>
+                          <span className="text-[10px] font-mono text-slate-500 ml-2">FAR {p.farValue.toFixed(1)}</span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {busts.length > 0 && (
+                  <div className="rounded-lg border border-red-300 bg-red-50/50 px-4 py-3">
+                    <div className="text-[10px] font-semibold uppercase tracking-wider text-red-700 mb-2">Underperforming</div>
+                    {busts.map((p) => (
+                      <div key={p.playerName} className="flex items-center justify-between py-1 border-b border-red-200/50 last:border-0">
+                        <div>
+                          <span className="text-[12px] font-medium text-slate-700">{p.playerName}</span>
+                          <span className="text-[10px] text-slate-500 ml-1">Rd {p.round}</span>
+                        </div>
+                        <span className="text-[10px] font-mono text-red-600">FAR {p.farValue.toFixed(1)}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Full draft card */}
+            <div className="rounded-lg border border-border overflow-x-auto">
+              <table className="w-full text-[12px]">
+                <thead>
+                  <tr className="border-b border-border bg-surface text-[10px] uppercase tracking-wider text-slate-500">
+                    <th className="px-3 py-2 text-left">Rd</th>
+                    <th className="px-3 py-2 text-left">Player</th>
+                    <th className="px-2 py-2 text-center">Pick</th>
+                    <th className="px-2 py-2 text-center">ADP</th>
+                    <th className="px-2 py-2 text-center">FAR</th>
+                    <th className="px-2 py-2 text-center">Grade</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {graded.map((p) => (
+                    <tr key={p.playerName} className={`border-b border-border/50 ${p.isSteal ? "bg-emerald-50/50" : p.isBust ? "bg-red-50/50" : ""}`}>
+                      <td className="px-3 py-1.5 font-mono text-slate-500">{p.round}</td>
+                      <td className="px-3 py-1.5">
+                        <span className="font-medium text-slate-700">{p.playerName}</span>
+                        {p.keeper && <span className="text-[9px] text-orange-600 ml-1">K</span>}
+                      </td>
+                      <td className="px-2 py-1.5 text-center font-mono tabular-nums text-slate-500">#{p.pick}</td>
+                      <td className="px-2 py-1.5 text-center font-mono tabular-nums">
+                        {p.adp != null ? (
+                          <span className={p.adpDiff !== null && p.adpDiff > 0 ? "text-emerald-600" : p.adpDiff !== null && p.adpDiff < -10 ? "text-red-600" : "text-slate-500"}>
+                            {p.adp.toFixed(0)}
+                          </span>
+                        ) : <span className="text-slate-400">N/A</span>}
+                      </td>
+                      <td className={`px-2 py-1.5 text-center font-mono tabular-nums font-bold ${
+                        p.farValue >= 2 ? "text-emerald-600" : p.farValue < 0 ? "text-red-600" : "text-slate-600"
+                      }`}>{p.farValue.toFixed(1)}</td>
+                      <td className={`px-2 py-1.5 text-center font-bold ${p.gradeColor}`}>{p.grade}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        );
+      })()}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Complete assistant GM feature set adding live data integration across 7 pages:

- **GM Dashboard**: Full 16-category health grid with rank badges (green/yellow/red), roster diagnosis action items from the analysis API, consolidated roster alerts panel
- **Season Timeline** (new page at `/gm/schedule-outlook`): Playoff math with rank targets and wins-per-week needed, remaining schedule difficulty visualization, critical window detection
- **Opponent Scouting**: Current-season overlay with live ESPN data showing strong/weak categories, H2H record against each opponent, roster activity classification (buyer/seller)
- **Trade Intelligence**: Buyer/seller board classifying teams by standings with top available talent listed on seller teams and weak categories on buyer teams
- **Category Intel**: In-season category standings grid showing your rank in each of the 16 categories, colored by weight tier, with weighted strength summary
- **Draft Strategy**: Post-draft grade card with steal/bust analysis, full pick-by-pick FAR grading table
- **Roster Analysis**: Position-by-position comparison of rostered players vs best available free agents with upgrade indicators

## Changes
- 8 files changed, 1222 insertions, 106 deletions
- 1 new page (`/gm/schedule-outlook`)
- 7 enhanced existing pages
- All existing tests pass (190/190)
- TypeScript strict mode clean

## Test plan
- [ ] Verify GM Dashboard loads with category health grid and action items
- [ ] Verify Season Timeline shows playoff math and schedule difficulty
- [ ] Verify Scouting page shows current-season overlay with live data
- [ ] Verify Trade Room shows buyer/seller board
- [ ] Verify Category Intel shows in-season standings grid
- [ ] Verify Draft Strategy shows draft grade card
- [ ] Verify Roster page shows position analysis with FA comparison
- [ ] Run `npx tsc --noEmit` (clean)
- [ ] Run `npx vitest run` (190 tests pass)