### PR TITLE
Fix lint errors, standardize shared utilities, remove dead code

### DIFF
--- a/web/src/app/api/analysis/advisor/route.ts
+++ b/web/src/app/api/analysis/advisor/route.ts
@@ -1,7 +1,7 @@
 import { espnFetch, hasEspnCreds, STAT_ID_MAP, getCurrentMatchupPeriod, getMatchupDates } from "@/lib/espn";
 import type { EspnLeagueData, EspnScoreByStat, EspnScheduleRecord } from "@/types/espn";
 import logger from "@/lib/logger";
-import { isPunt, categoryWeight } from "@/lib/category-weights";
+import { isPunt, categoryWeight, ALL_CATS_BY_WEIGHT } from "@/lib/category-weights";
 
 interface Recommendation {
   type: "score" | "target" | "alert" | "stream" | "sit";
@@ -11,7 +11,7 @@ interface Recommendation {
 }
 
 const MY_TEAM_ID = parseInt(process.env.MY_ESPN_TEAM_ID ?? "0");
-const CATS_ORDER = ["H", "R", "HR", "TB", "RBI", "BB", "SB", "AVG", "K", "QS", "W", "L", "SV", "HD", "ERA", "WHIP"];
+const CATS_ORDER = ALL_CATS_BY_WEIGHT;
 const LOWER_IS_BETTER = new Set(["ERA", "WHIP", "L"]);
 
 export async function GET(req: Request) {

--- a/web/src/app/api/analysis/roster-diagnosis/route.ts
+++ b/web/src/app/api/analysis/roster-diagnosis/route.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/category-weights";
 import type { EspnLeagueData, EspnRosterEntry, EspnStatBlock, EspnScoreByStat, EspnScheduleRecord } from "@/types/espn";
 import logger from "@/lib/logger";
+import { safeDivide } from "@/lib/sanitize";
 
 const MY_TEAM_ID = parseInt(process.env.MY_ESPN_TEAM_ID ?? "9");
 const CATS_ORDER = ALL_CATS_BY_WEIGHT;
@@ -29,11 +30,6 @@ function clean(v: unknown): number {
   return 0;
 }
 
-function safeDivide(a: number, b: number, fallback = 0): number {
-  if (b === 0 || !Number.isFinite(a) || !Number.isFinite(b)) return fallback;
-  const result = a / b;
-  return Number.isFinite(result) ? result : fallback;
-}
 
 // Build season stats from matchup schedule (proven approach from league-stats)
 function buildSeasonStats(

--- a/web/src/app/api/espn/league-stats/route.ts
+++ b/web/src/app/api/espn/league-stats/route.ts
@@ -33,7 +33,6 @@ const CATS_ORDER = ["H", "R", "HR", "TB", "RBI", "BB", "SB", "AVG", "K", "QS", "
 const BAT_CATS = ["H", "R", "HR", "TB", "RBI", "BB", "SB", "AVG"];
 const PIT_CATS = ["K", "QS", "W", "L", "SV", "HD", "ERA", "WHIP"];
 const LOWER_IS_BETTER = new Set(["ERA", "WHIP", "L"]);
-const RATE_STATS = new Set(["AVG", "ERA", "WHIP"]);
 
 // Component stat IDs needed to reconstruct rate stats across weeks
 // These are present in ESPN's scoreByStat alongside the scored categories

--- a/web/src/app/api/espn/matchup-tracker/route.ts
+++ b/web/src/app/api/espn/matchup-tracker/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 import { espnFetch, hasEspnCreds, STAT_ID_MAP, getMatchupDates, getCurrentMatchupPeriod, SEASON_START, dayToDate } from "@/lib/espn";
 import type { EspnLeagueData, EspnScoreByStat, EspnScheduleRecord } from "@/types/espn";
 import logger from "@/lib/logger";
+import { ALL_CATS_BY_WEIGHT } from "@/lib/category-weights";
 
 export interface DailyPoints {
   date: string;
@@ -60,15 +61,7 @@ export interface MatchupTrackerData {
 
 const MY_TEAM_ID = parseInt(process.env.MY_ESPN_TEAM_ID ?? "0");
 
-const CATS_ORDER = ["H", "R", "HR", "TB", "RBI", "BB", "SB", "AVG", "K", "QS", "W", "L", "SV", "HD", "ERA", "WHIP"];
-
-// Raw stat IDs in ESPN matchup scoreByStat (includes component stats)
-const BAT_RAW_IDS: Record<number, string> = {
-  0: "AB", 1: "H", 20: "R", 5: "HR", 8: "TB", 21: "RBI", 10: "BB", 23: "SB",
-};
-const PIT_RAW_IDS: Record<number, string> = {
-  34: "IP", 35: "H", 39: "ER", 38: "BB", 48: "K", 63: "QS", 53: "W", 54: "L", 57: "SV", 60: "HD",
-};
+const CATS_ORDER = ALL_CATS_BY_WEIGHT;
 
 const cleanVal = (v: unknown): number => {
   if (typeof v === "number" && Number.isFinite(v)) return v;

--- a/web/src/app/api/espn/matchup/route.ts
+++ b/web/src/app/api/espn/matchup/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 import { espnFetch, hasEspnCreds, POS_MAP, SLOT_MAP, INJURY_MAP, STAT_ID_MAP, getProTeam, getMatchupDates, getCurrentMatchupPeriod } from "@/lib/espn";
 import type { EspnLeagueData, EspnRosterEntry, EspnStatBlock, EspnScoreByStat, EspnScheduleRecord } from "@/types/espn";
 import logger from "@/lib/logger";
+import { ALL_CATS_BY_WEIGHT } from "@/lib/category-weights";
 
 export interface MatchupCatResult {
   cat: string;
@@ -42,7 +43,7 @@ export interface MatchupData {
 }
 
 const MY_TEAM_ID = parseInt(process.env.MY_ESPN_TEAM_ID ?? "0");
-const CATS_ORDER = ["H", "R", "HR", "TB", "RBI", "BB", "SB", "AVG", "K", "QS", "W", "L", "SV", "HD", "ERA", "WHIP"];
+const CATS_ORDER = ALL_CATS_BY_WEIGHT;
 
 // Player stat IDs (raw player context — different from scoring stat IDs)
 const PLAYER_STAT_MAP: Record<string, string> = {

--- a/web/src/app/api/espn/power-rankings/route.ts
+++ b/web/src/app/api/espn/power-rankings/route.ts
@@ -2,9 +2,10 @@ export const dynamic = "force-dynamic";
 import { espnFetch, hasEspnCreds, STAT_ID_MAP } from "@/lib/espn";
 import { getCategoryWeights } from "@/lib/data";
 import logger from "@/lib/logger";
+import { ALL_CATS_BY_WEIGHT } from "@/lib/category-weights";
 
 const MY_TEAM_ID = parseInt(process.env.MY_ESPN_TEAM_ID ?? "0");
-const CATS_ORDER = ["H", "R", "HR", "TB", "RBI", "BB", "SB", "AVG", "K", "QS", "W", "L", "SV", "HD", "ERA", "WHIP"];
+const CATS_ORDER = ALL_CATS_BY_WEIGHT;
 const BAT_CATS = ["H", "R", "HR", "TB", "RBI", "BB", "SB", "AVG"];
 const PIT_CATS = ["K", "QS", "W", "L", "SV", "HD", "ERA", "WHIP"];
 const LOWER_IS_BETTER = new Set(["ERA", "WHIP", "L"]);

--- a/web/src/app/draft/pick-value/page.tsx
+++ b/web/src/app/draft/pick-value/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import { sanitizeNum } from "@/lib/sanitize";
 
 interface OwnerSeason {
   year: number;
@@ -12,9 +13,6 @@ interface OwnerSeason {
   ties: number;
 }
 
-function safeNum(val: number): number {
-  return Number.isFinite(val) ? val : 0;
-}
 
 export default function PickValuePage() {
   const [data, setData] = useState<OwnerSeason[]>([]);
@@ -67,10 +65,10 @@ export default function PickValuePage() {
         const yearTeams = byYear[year];
         if (!yearTeams) continue;
         const sorted = [...yearTeams].sort((a, b) => {
-          const totalA = safeNum(a.wins) + safeNum(a.losses) + safeNum(a.ties);
-          const totalB = safeNum(b.wins) + safeNum(b.losses) + safeNum(b.ties);
-          const pctA = totalA > 0 ? safeNum(a.wins) / totalA : 0;
-          const pctB = totalB > 0 ? safeNum(b.wins) / totalB : 0;
+          const totalA = sanitizeNum(a.wins) + sanitizeNum(a.losses) + sanitizeNum(a.ties);
+          const totalB = sanitizeNum(b.wins) + sanitizeNum(b.losses) + sanitizeNum(b.ties);
+          const pctA = totalA > 0 ? sanitizeNum(a.wins) / totalA : 0;
+          const pctB = totalB > 0 ? sanitizeNum(b.wins) / totalB : 0;
           return pctB - pctA;
         });
         if (pick <= sorted.length) {
@@ -81,9 +79,9 @@ export default function PickValuePage() {
       const avg = standings.reduce((a, b) => a + b, 0) / standings.length;
       results.push({
         pick,
-        avgStanding: safeNum(avg),
-        top3Pct: safeNum((standings.filter((s) => s <= 3).length / standings.length) * 100),
-        bottom3Pct: safeNum((standings.filter((s) => s >= leagueSize - 2).length / standings.length) * 100),
+        avgStanding: sanitizeNum(avg),
+        top3Pct: sanitizeNum((standings.filter((s) => s <= 3).length / standings.length) * 100),
+        bottom3Pct: sanitizeNum((standings.filter((s) => s >= leagueSize - 2).length / standings.length) * 100),
         bestFinish: Math.min(...standings),
         worstFinish: Math.max(...standings),
         seasons: standings.length,
@@ -105,9 +103,9 @@ export default function PickValuePage() {
       const yearTeams = byYear[year];
       if (!yearTeams) continue;
       const sorted = [...yearTeams].sort((a, b) => {
-        const totalA = safeNum(a.wins) + safeNum(a.losses) + safeNum(a.ties);
-        const totalB = safeNum(b.wins) + safeNum(b.losses) + safeNum(b.ties);
-        return (totalB > 0 ? safeNum(b.wins) / totalB : 0) - (totalA > 0 ? safeNum(a.wins) / totalA : 0);
+        const totalA = sanitizeNum(a.wins) + sanitizeNum(a.losses) + sanitizeNum(a.ties);
+        const totalB = sanitizeNum(b.wins) + sanitizeNum(b.losses) + sanitizeNum(b.ties);
+        return (totalB > 0 ? sanitizeNum(b.wins) / totalB : 0) - (totalA > 0 ? sanitizeNum(a.wins) / totalA : 0);
       });
       sorted.forEach((s, i) => {
         pairs.push({ pick: i + 1, standing: s.standing, year: s.year, owner: s.owner });

--- a/web/src/app/gm/bullpen/page.tsx
+++ b/web/src/app/gm/bullpen/page.tsx
@@ -359,7 +359,7 @@ export default function BullpenPage() {
       setTeams(rosterData);
       if (matchupData.myTeamId) setMyTeamId(matchupData.myTeamId);
       if (matchupData.categories) {
-        const pitCats = (matchupData.categories as any[]).filter((c: any) =>
+        const pitCats = (matchupData.categories as { cat: string; myValue: number | null; oppValue: number | null; result: string }[]).filter((c) =>
           ["K", "QS", "W", "L", "SV", "HD", "ERA", "WHIP"].includes(c.cat)
         );
         setMatchupCats(pitCats);

--- a/web/src/app/gm/diagnosis/page.tsx
+++ b/web/src/app/gm/diagnosis/page.tsx
@@ -5,6 +5,7 @@ import {
   categoryTierClass,
   LOWER_IS_BETTER,
 } from "@/lib/category-weights";
+import { EspnAuthRequired } from "@/components/EspnAuthRequired";
 
 interface CategoryRanking {
   cat: string;
@@ -156,16 +157,8 @@ export default function DiagnosisPage() {
     );
   }
 
-  if (error === "ESPN_CREDS_MISSING") {
-    return (
-      <div className="mx-auto max-w-lg px-4 py-16 text-center">
-        <div className="text-[11px] font-semibold uppercase tracking-widest text-orange-600/60">Setup Required</div>
-        <div className="mt-3 text-xl font-bold text-gray-900">Connect ESPN Credentials</div>
-        <div className="mt-3 text-[13px] text-slate-500">
-          Add ESPN_S2, ESPN_SWID, and MY_ESPN_TEAM_ID as environment variables.
-        </div>
-      </div>
-    );
+  if (error === "ESPN_CREDS_MISSING" || error === "MY_ESPN_TEAM_ID_MISSING") {
+    return <div className="flex min-h-[70vh] items-center justify-center px-4"><EspnAuthRequired /></div>;
   }
 
   if (error || !data) {

--- a/web/src/app/gm/free-agents/page.tsx
+++ b/web/src/app/gm/free-agents/page.tsx
@@ -79,6 +79,13 @@ const LOWER_IS_BETTER = new Set(["ERA", "WHIP", "L"]);
 const BAT_CATS = ["AVG", "HR", "R", "RBI", "SB", "H", "BB", "TB"];
 const PIT_CATS = ["K", "QS", "W", "SV", "HD", "ERA", "WHIP"];
 
+function getPlayerStats(p: PlayerStats, period: "season" | "last7" | "last15" | "last30"): Record<string, number> {
+  if (period === "last7") return p.last7Stats;
+  if (period === "last15") return p.last15Stats;
+  if (period === "last30") return p.last30Stats;
+  return p.seasonStats;
+}
+
 function fmtStat(cat: string, val: number | undefined): string {
   if (val === undefined || val === null || !Number.isFinite(val)) return "-";
   const v = sanitizeNum(val);
@@ -217,16 +224,11 @@ export default function FreeAgentsPage() {
       .slice(0, 20);
   }, [showStreaming, freeAgents, pitcherStarts, zScoreMap]);
 
-  function getStats(p: PlayerStats): Record<string, number> {
-    if (statPeriod === "last7") return p.last7Stats;
-    if (statPeriod === "last15") return p.last15Stats;
-    if (statPeriod === "last30") return p.last30Stats;
-    return p.seasonStats;
-  }
-
   const isPitcherFilter = posFilter === "SP" || posFilter === "RP";
 
   const filtered = useMemo(() => {
+
+
     let list = freeAgents;
 
     if (posFilter !== "ALL") {
@@ -260,8 +262,8 @@ export default function FreeAgentsPage() {
         return sanitizeNum(bZ?.zScores[weaknessFilter] ?? -999) - sanitizeNum(aZ?.zScores[weaknessFilter] ?? -999);
       }
 
-      const aStats = getStats(a);
-      const bStats = getStats(b);
+      const aStats = getPlayerStats(a, statPeriod);
+      const bStats = getPlayerStats(b, statPeriod);
       const aVal = sanitizeNum(aStats[sortBy] ?? (LOWER_IS_BETTER.has(sortBy) ? 999 : -999));
       const bVal = sanitizeNum(bStats[sortBy] ?? (LOWER_IS_BETTER.has(sortBy) ? 999 : -999));
       return LOWER_IS_BETTER.has(sortBy) ? aVal - bVal : bVal - aVal;
@@ -272,13 +274,14 @@ export default function FreeAgentsPage() {
 
   const sortOptions = isPitcherFilter ? PIT_SORT_OPTIONS : BAT_SORT_OPTIONS;
 
-  useEffect(() => {
-    if (posFilter === "SP" || posFilter === "RP") {
+  function handlePosFilter(pos: string) {
+    setPosFilter(pos);
+    if (pos === "SP" || pos === "RP") {
       if (!PIT_SORT_OPTIONS.find((o) => o.key === sortBy)) setSortBy("FAR");
     } else {
       if (!BAT_SORT_OPTIONS.find((o) => o.key === sortBy)) setSortBy("FAR");
     }
-  }, [posFilter, sortBy]);
+  }
 
   if (loading) return <div className="flex h-64 items-center justify-center text-slate-500">Loading free agents...</div>;
   if (error === "ESPN_CREDS_MISSING") {
@@ -468,7 +471,7 @@ export default function FreeAgentsPage() {
         {/* Position filter */}
         <div className="flex gap-0.5 rounded bg-surface border border-border p-0.5">
           {POSITIONS.map((pos) => (
-            <button key={pos} onClick={() => setPosFilter(pos)}
+            <button key={pos} onClick={() => handlePosFilter(pos)}
               className={`rounded px-2 py-1 text-[10px] font-bold transition-colors ${
                 posFilter === pos ? "bg-black/10 text-gray-900" : "text-slate-500 hover:text-slate-700"
               }`}>
@@ -525,7 +528,7 @@ export default function FreeAgentsPage() {
           </thead>
           <tbody>
             {filtered.map((p, i) => {
-              const stats = getStats(p);
+              const stats = getPlayerStats(p, statPeriod);
               const zPlayer = zScoreMap.get(p.playerId);
               const zTotal = sanitizeNum(zPlayer?.zTotal ?? 0);
               const far = sanitizeNum(zPlayer?.far ?? 0);

--- a/web/src/app/gm/layout.tsx
+++ b/web/src/app/gm/layout.tsx
@@ -10,6 +10,7 @@ const SUB_LINKS = [
   { href: "/gm/roster-schedule", label: "Roster Schedule" },
   { href: "/gm/diagnosis", label: "Diagnosis" },
   { href: "/gm/bullpen", label: "Bullpen" },
+  { href: "/gm/starts", label: "Starts" },
   { href: "/gm/sp-scout", label: "SP Scout" },
   { href: "/gm/schedule-outlook", label: "Timeline" },
   { href: "/gm/season-log", label: "Season Log" },

--- a/web/src/app/gm/matchup-tracker/page.tsx
+++ b/web/src/app/gm/matchup-tracker/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { DataFreshness } from "@/components/DataFreshness";
 import { EspnAuthRequired } from "@/components/EspnAuthRequired";
-import { sanitizeNum, safeDivide, formatStat } from "@/lib/sanitize";
+import { sanitizeNum } from "@/lib/sanitize";
 import { categoryTierClass, LOWER_IS_BETTER } from "@/lib/category-weights";
 
 interface TeamRawStats {
@@ -175,7 +175,16 @@ export default function MatchupTrackerPage() {
       .finally(() => setLoading(false));
   }, []);
 
-  useEffect(() => { fetchData(); }, [fetchData]);
+  useEffect(() => {
+    fetch("/api/espn/matchup-tracker")
+      .then((r) => r.json())
+      .then((d: TrackerData & { error?: string }) => {
+        if (d.error) { setError(d.error); return; }
+        setData(d);
+      })
+      .catch(() => setError("FETCH_FAILED"))
+      .finally(() => setLoading(false));
+  }, []);
 
   const winCount = useMemo(() => data?.catResults.filter((c) => c.result === "WIN").length ?? 0, [data]);
   const lossCount = useMemo(() => data?.catResults.filter((c) => c.result === "LOSS").length ?? 0, [data]);

--- a/web/src/app/gm/page.tsx
+++ b/web/src/app/gm/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { EspnAuthRequired } from "@/components/EspnAuthRequired";
 import { sanitizeNum } from "@/lib/sanitize";
-import { CATEGORY_WEIGHTS, HIGH_IMPACT_CATS, LOWER_IS_BETTER, isPunt, categoryTier } from "@/lib/category-weights";
+import { CATEGORY_WEIGHTS, LOWER_IS_BETTER, isPunt, categoryTier, ALL_CATS_BY_WEIGHT } from "@/lib/category-weights";
 
 interface MatchupCat {
   cat: string;
@@ -64,7 +64,7 @@ interface DiagnosisData {
   actionItems: ActionItem[];
 }
 
-const ALL_CATS = ["TB", "HR", "R", "RBI", "H", "W", "K", "WHIP", "QS", "ERA", "SB", "BB", "AVG", "L", "HD", "SV"];
+const ALL_CATS = ALL_CATS_BY_WEIGHT;
 const IL_STATUSES = new Set(["SEVEN_DAY_DL", "TEN_DAY_DL", "FIFTEEN_DAY_DL", "SIXTY_DAY_DL", "OUT"]);
 
 function rankColor(rank: number): string {

--- a/web/src/app/gm/roster-schedule/page.tsx
+++ b/web/src/app/gm/roster-schedule/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { DataFreshness } from "@/components/DataFreshness";
 import { EspnAuthRequired } from "@/components/EspnAuthRequired";
-import { sanitizeNum } from "@/lib/sanitize";
+
 
 interface MatchupPlayer {
   name: string;
@@ -185,7 +185,6 @@ export default function RosterSchedulePage() {
         if (d.error) { setError(d.error); return; }
         setMatchup(d);
 
-        // Fetch schedule grid for the matchup period
         const startDate = d.matchupStartDate ?? new Date().toISOString().slice(0, 10);
         const endDate = d.matchupEndDate ?? (() => {
           const e = new Date(); e.setDate(e.getDate() + 7); return e.toISOString().slice(0, 10);
@@ -200,7 +199,26 @@ export default function RosterSchedulePage() {
       .finally(() => setLoading(false));
   }, []);
 
-  useEffect(() => { fetchData(); }, [fetchData]);
+  useEffect(() => {
+    fetch("/api/espn/matchup")
+      .then((r) => r.json())
+      .then((d: MatchupData & { error?: string }) => {
+        if (d.error) { setError(d.error); return; }
+        setMatchup(d);
+
+        const startDate = d.matchupStartDate ?? new Date().toISOString().slice(0, 10);
+        const endDate = d.matchupEndDate ?? (() => {
+          const e = new Date(); e.setDate(e.getDate() + 7); return e.toISOString().slice(0, 10);
+        })();
+        return fetch(`/api/mlb/schedule-grid?startDate=${startDate}&endDate=${endDate}`)
+          .then((r) => r.json())
+          .then((g) => {
+            if (!g.error) setGrid(g);
+          });
+      })
+      .catch(() => setError("FETCH_FAILED"))
+      .finally(() => setLoading(false));
+  }, []);
 
   const days = useMemo(() => {
     if (!matchup?.matchupStartDate || !matchup?.matchupEndDate) return [];

--- a/web/src/app/gm/roster/page.tsx
+++ b/web/src/app/gm/roster/page.tsx
@@ -450,6 +450,37 @@ function GmAdvisor() {
 
 
 
+function RosterSection({ label, players, borderColor = "border-border", schedule, zScoreMap, playerStatsMap, showDetail, expandedPlayer, onToggle, allZScores }: {
+  label: string;
+  players: RosterPlayer[];
+  borderColor?: string;
+  schedule: Record<string, TeamSchedule>;
+  zScoreMap: Map<string, ZScorePlayer>;
+  playerStatsMap: Map<string, PlayerSeasonStats>;
+  showDetail: boolean;
+  expandedPlayer: string | null;
+  onToggle: (name: string) => void;
+  allZScores: ZScorePlayer[];
+}) {
+  return (
+    <div className={`rounded-lg border ${borderColor} bg-surface`}>
+      <div className={`border-b ${borderColor} px-3 py-2 flex items-center justify-between`}>
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-600">{label}</span>
+        <span className="text-[10px] tabular-nums text-slate-400">{players.length}</span>
+      </div>
+      {players.map((p, i) => (
+        <PlayerRow key={i} player={p} schedule={schedule[p.proTeam] ?? null}
+          zp={zScoreMap.get(p.name)} stats={playerStatsMap.get(p.name)} showDetail={showDetail}
+          expanded={expandedPlayer === p.name} onToggle={() => onToggle(p.name)}
+          allZScores={allZScores} />
+      ))}
+      {players.length === 0 && (
+        <div className="px-3 py-3 text-[11px] text-slate-400">-</div>
+      )}
+    </div>
+  );
+}
+
 export default function RosterPage() {
   const [teams, setTeams] = useState<EspnTeam[]>([]);
   const [schedule, setSchedule] = useState<Record<string, TeamSchedule>>({});
@@ -547,24 +578,6 @@ export default function RosterPage() {
     );
   }
 
-  const Section = ({ label, players, borderColor = "border-border" }: { label: string; players: RosterPlayer[]; borderColor?: string }) => (
-    <div className={`rounded-lg border ${borderColor} bg-surface`}>
-      <div className={`border-b ${borderColor} px-3 py-2 flex items-center justify-between`}>
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-600">{label}</span>
-        <span className="text-[10px] tabular-nums text-slate-400">{players.length}</span>
-      </div>
-      {players.map((p, i) => (
-        <PlayerRow key={i} player={p} schedule={schedule[p.proTeam] ?? null}
-          zp={zScoreMap.get(p.name)} stats={playerStatsMap.get(p.name)} showDetail={showStats}
-          expanded={expandedPlayer === p.name} onToggle={() => togglePlayer(p.name)}
-          allZScores={allZScores} />
-      ))}
-      {players.length === 0 && (
-        <div className="px-3 py-3 text-[11px] text-slate-400">-</div>
-      )}
-    </div>
-  );
-
   return (
     <div className="mx-auto max-w-6xl px-4 py-6">
       {/* Header */}
@@ -640,12 +653,20 @@ export default function RosterPage() {
 
       {/* Roster grid */}
       <div className="grid gap-4 lg:grid-cols-3">
-        <Section label="Batting" players={batters} borderColor="border-orange-300" />
-        <Section label="Pitching" players={pitchers} />
+        <RosterSection label="Batting" players={batters} borderColor="border-orange-300"
+          schedule={schedule} zScoreMap={zScoreMap} playerStatsMap={playerStatsMap}
+          showDetail={showStats} expandedPlayer={expandedPlayer} onToggle={togglePlayer} allZScores={allZScores} />
+        <RosterSection label="Pitching" players={pitchers}
+          schedule={schedule} zScoreMap={zScoreMap} playerStatsMap={playerStatsMap}
+          showDetail={showStats} expandedPlayer={expandedPlayer} onToggle={togglePlayer} allZScores={allZScores} />
         <div className="space-y-4">
-          <Section label="Bench" players={bench} />
+          <RosterSection label="Bench" players={bench}
+            schedule={schedule} zScoreMap={zScoreMap} playerStatsMap={playerStatsMap}
+            showDetail={showStats} expandedPlayer={expandedPlayer} onToggle={togglePlayer} allZScores={allZScores} />
           {il.length > 0 && (
-            <Section label="Injured List" players={il} borderColor="border-red-300" />
+            <RosterSection label="Injured List" players={il} borderColor="border-red-300"
+              schedule={schedule} zScoreMap={zScoreMap} playerStatsMap={playerStatsMap}
+              showDetail={showStats} expandedPlayer={expandedPlayer} onToggle={togglePlayer} allZScores={allZScores} />
           )}
         </div>
       </div>
@@ -677,7 +698,6 @@ export default function RosterPage() {
           roster={resolvedTeam.roster}
           zScoreMap={zScoreMap}
           allZScores={allZScores}
-          myTeamId={resolvedTeam.id}
         />
       )}
 
@@ -704,12 +724,10 @@ function PositionAnalysis({
   roster,
   zScoreMap,
   allZScores,
-  myTeamId,
 }: {
   roster: RosterPlayer[];
   zScoreMap: Map<string, ZScorePlayer>;
   allZScores: ZScorePlayer[];
-  myTeamId: number;
 }) {
   const positionData = useMemo(() => {
     return POS_SLOTS.map((ps) => {

--- a/web/src/app/gm/schedule-outlook/page.tsx
+++ b/web/src/app/gm/schedule-outlook/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo, useRef } from "react";
 import { mean, stddev } from "@/lib/z-scores";
 import { CATEGORY_WEIGHTS } from "@/lib/category-weights";
 import { EspnAuthRequired } from "@/components/EspnAuthRequired";
-import { sanitizeNum, safeDivide } from "@/lib/sanitize";
+import { safeDivide } from "@/lib/sanitize";
 
 interface MatchupWeek {
   period: number;
@@ -247,14 +247,6 @@ export default function ScheduleOutlookPage() {
 
   const totalWeeks = schedule.weeks.length;
   const pastWeeks = schedule.weeks.filter((w) => w.period < schedule.currentMatchupPeriod);
-  const pastRecord = pastWeeks.reduce(
-    (acc, w) => {
-      const r = h2hMatchups[w.period];
-      if (!r) return acc;
-      return { w: acc.w + r.myWins, l: acc.l + r.myLosses, t: acc.t + r.myTies };
-    },
-    { w: 0, l: 0, t: 0 }
-  );
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-6">

--- a/web/src/app/gm/season-log/page.tsx
+++ b/web/src/app/gm/season-log/page.tsx
@@ -162,7 +162,16 @@ export default function SeasonLogPage() {
       .finally(() => setLoading(false));
   }, []);
 
-  useEffect(() => { fetchData(); }, [fetchData]);
+  useEffect(() => {
+    fetch("/api/espn/season-log")
+      .then((r) => r.json())
+      .then((d: SeasonLogData & { error?: string }) => {
+        if (d.error) { setError(d.error); return; }
+        setData(d);
+      })
+      .catch(() => setError("FETCH_FAILED"))
+      .finally(() => setLoading(false));
+  }, []);
 
   // Compute best/worst weeks for each stat
   const { batBest, batWorst, pitBest, pitWorst, batAvg, pitAvg } = useMemo(() => {

--- a/web/src/app/gm/sp-scout/page.tsx
+++ b/web/src/app/gm/sp-scout/page.tsx
@@ -144,7 +144,6 @@ export default function SPScoutPage() {
         setZScores(zData);
         setStarts(startsData);
 
-        // Fetch probable pitchers for current + next week
         const startDate = startsData.currentDates?.start ?? new Date().toISOString().slice(0, 10);
         const endDate = startsData.nextDates?.end ?? (() => {
           const d = new Date(); d.setDate(d.getDate() + 14); return d.toISOString().slice(0, 10);
@@ -159,13 +158,35 @@ export default function SPScoutPage() {
       .finally(() => setLoading(false));
   }, []);
 
-  useEffect(() => { fetchData(); }, [fetchData]);
+  useEffect(() => {
+    Promise.all([
+      fetch("/api/analysis/z-scores").then((r) => r.json()),
+      fetch("/api/espn/starts").then((r) => r.json()),
+    ])
+      .then(([zData, startsData]) => {
+        if (zData.error) { setError(zData.error); return; }
+        if (startsData.error) { setError(startsData.error); return; }
+        setZScores(zData);
+        setStarts(startsData);
+
+        const startDate = startsData.currentDates?.start ?? new Date().toISOString().slice(0, 10);
+        const endDate = startsData.nextDates?.end ?? (() => {
+          const d = new Date(); d.setDate(d.getDate() + 14); return d.toISOString().slice(0, 10);
+        })();
+        return fetch(`/api/mlb/probable-pitchers?startDate=${startDate}&endDate=${endDate}`)
+          .then((r) => r.json())
+          .then((pData) => {
+            if (!pData.error) setProbables(pData);
+          });
+      })
+      .catch(() => setError("FETCH_FAILED"))
+      .finally(() => setLoading(false));
+  }, []);
 
   const scouts = useMemo((): ScoutEntry[] => {
     if (!zScores || !starts) return [];
 
     const rosteredSet = new Set(starts.rosteredPitchers);
-    const myTeamId = starts.myTeamId;
 
     // Build starts lookup from ESPN data
     const ppLookup: Record<string, { thisWeek: number; nextWeek: number }> = {};

--- a/web/src/app/gm/today/page.tsx
+++ b/web/src/app/gm/today/page.tsx
@@ -32,24 +32,9 @@ interface TeamSchedule {
   isHome: boolean | null;
 }
 
-interface WeatherData {
-  temp: number | null;
-  condition: string | null;
-  rainChance: number | null;
-  icon: string;
-}
-
 const BATTER_SLOTS = new Set([0, 1, 2, 3, 4, 5, 6, 7, 8, 12]);
 const PITCHER_SLOTS = new Set([13, 14, 15]);
 const BENCH_SLOT = 16;
-
-
-function weatherIcon(condition: string | null, rainChance: number | null): { icon: string; color: string; label: string } {
-  if (rainChance !== null && rainChance >= 60) return { icon: "!", color: "text-red-600 bg-red-50 border-red-200", label: `${rainChance}% rain` };
-  if (rainChance !== null && rainChance >= 30) return { icon: "~", color: "text-orange-600 bg-orange-50 border-orange-200", label: `${rainChance}% rain` };
-  return { icon: "", color: "", label: "" };
-}
-
 
 interface BvpStats {
   summary: string;

--- a/web/src/app/gm/trade/page.tsx
+++ b/web/src/app/gm/trade/page.tsx
@@ -636,7 +636,6 @@ export default function TradeRoomPage() {
                 {standings.filter((t) => t.rank > Math.ceil(standings.length / 2) && t.teamId !== myTeamId)
                   .sort((a, b) => b.rank - a.rank)
                   .map((t) => {
-                    const roster = teams.find((r) => r.id === t.teamId);
                     const topPlayers = zScorePlayers
                       .filter((p) => p.onTeamId === t.teamId && p.far >= 2.0)
                       .sort((a, b) => b.far - a.far)

--- a/web/src/app/league/acquisition-patterns/page.tsx
+++ b/web/src/app/league/acquisition-patterns/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import { EspnAuthRequired } from "@/components/EspnAuthRequired";
 
 interface RosterPlayer {
   name: string;
@@ -88,14 +89,7 @@ export default function AcquisitionPatternsPage() {
 
   if (loading) return <div className="flex h-64 items-center justify-center text-slate-500">Loading...</div>;
   if (error === "ESPN_CREDS_MISSING" || error === "MY_ESPN_TEAM_ID_MISSING") {
-    return (
-      <div className="flex min-h-[70vh] items-center justify-center px-4">
-        <div className="mx-auto max-w-lg rounded-xl border border-border bg-surface px-8 py-10 text-center">
-          <div className="text-[11px] font-semibold uppercase tracking-widest text-orange-600/60">Setup Required</div>
-          <div className="mt-3 text-xl font-bold text-gray-900">Connect ESPN Credentials</div>
-        </div>
-      </div>
-    );
+    return <div className="flex min-h-[70vh] items-center justify-center px-4"><EspnAuthRequired /></div>;
   }
   if (error) {
     return (

--- a/web/src/app/league/owner-tendencies/page.tsx
+++ b/web/src/app/league/owner-tendencies/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import { sanitizeNum } from "@/lib/sanitize";
 
 interface OwnerSeason {
   year: number;
@@ -28,9 +29,6 @@ interface OwnerSummary {
   recentTeamName: string;
 }
 
-function safeNum(val: number): number {
-  return Number.isFinite(val) ? val : 0;
-}
 
 export default function OwnerTendenciesPage() {
   const [data, setData] = useState<OwnerSeason[]>([]);
@@ -63,9 +61,9 @@ export default function OwnerTendenciesPage() {
         const bestFinish = standings.length > 0 ? Math.min(...standings) : 99;
         const worstFinish = standings.length > 0 ? Math.max(...standings) : 0;
         const top3Count = standings.filter((s) => s <= 3).length;
-        const totalWins = seasons.reduce((s, r) => s + safeNum(r.wins), 0);
-        const totalLosses = seasons.reduce((s, r) => s + safeNum(r.losses), 0);
-        const totalTies = seasons.reduce((s, r) => s + safeNum(r.ties), 0);
+        const totalWins = seasons.reduce((s, r) => s + sanitizeNum(r.wins), 0);
+        const totalLosses = seasons.reduce((s, r) => s + sanitizeNum(r.losses), 0);
+        const totalTies = seasons.reduce((s, r) => s + sanitizeNum(r.ties), 0);
         const total = totalWins + totalLosses + totalTies;
         const winPct = total > 0 ? totalWins / total : 0;
         const mean = avgStanding;
@@ -77,15 +75,15 @@ export default function OwnerTendenciesPage() {
         return {
           owner,
           seasons: seasons.length,
-          avgStanding: safeNum(avgStanding),
+          avgStanding: sanitizeNum(avgStanding),
           bestFinish,
           worstFinish,
           top3Count,
           totalWins,
           totalLosses,
           totalTies,
-          winPct: safeNum(winPct),
-          consistency: safeNum(consistency),
+          winPct: sanitizeNum(winPct),
+          consistency: sanitizeNum(consistency),
           years: sorted,
           recentTeamName: sorted[0]?.teamName ?? "",
         };
@@ -139,11 +137,6 @@ export default function OwnerTendenciesPage() {
       {/* Owner cards */}
       <div className="space-y-3">
         {owners.map((o, idx) => {
-          const standingColor = (s: number) =>
-            s === 1 ? "text-amber-500 font-bold" :
-            s <= 3 ? "text-emerald-600 font-bold" :
-            s <= 6 ? "text-slate-600" :
-            s <= 9 ? "text-orange-600" : "text-red-600";
           return (
             <div key={o.owner} className="rounded-lg border border-border bg-surface">
               <div className="border-b border-border px-4 py-3 flex items-center justify-between">

--- a/web/src/app/league/power-rankings/page.tsx
+++ b/web/src/app/league/power-rankings/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from "react";
 import { EspnAuthRequired } from "@/components/EspnAuthRequired";
+import { ALL_CATS_BY_WEIGHT } from "@/lib/category-weights";
 
 interface WeeklyTrendPoint {
   week: number;
@@ -80,7 +81,7 @@ function TrendIndicator({ change }: { change: number | null }) {
   );
 }
 
-function Sparkline({ points, current }: { points: WeeklyTrendPoint[]; current: number }) {
+function Sparkline({ points }: { points: WeeklyTrendPoint[] }) {
   if (points.length < 2) return null;
   const maxRank = 10;
   const w = 80;
@@ -101,7 +102,7 @@ function Sparkline({ points, current }: { points: WeeklyTrendPoint[]; current: n
   );
 }
 
-const CATS_ORDER = ["H", "R", "HR", "TB", "RBI", "BB", "SB", "AVG", "K", "QS", "W", "L", "SV", "HD", "ERA", "WHIP"];
+const CATS_ORDER = ALL_CATS_BY_WEIGHT;
 
 function catRankColor(rank: number): string {
   if (rank <= 2) return "bg-emerald-600 text-white";
@@ -208,7 +209,7 @@ export default function PowerRankingsPage() {
                     <TrendIndicator change={team.rankChange} />
                   </td>
                   <td className="px-3 py-3 text-center">
-                    <Sparkline points={team.weeklyTrend ?? []} current={data.currentWeek} />
+                    <Sparkline points={team.weeklyTrend ?? []} />
                   </td>
                 </tr>
                 {isExpanded && (

--- a/web/src/app/league/waiver-activity/page.tsx
+++ b/web/src/app/league/waiver-activity/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo } from "react";
+import { EspnAuthRequired } from "@/components/EspnAuthRequired";
 
 interface RosterPlayer {
   name: string;
@@ -57,14 +58,7 @@ export default function WaiverActivityPage() {
 
   if (loading) return <div className="flex h-64 items-center justify-center text-slate-500">Loading...</div>;
   if (error === "ESPN_CREDS_MISSING" || error === "MY_ESPN_TEAM_ID_MISSING") {
-    return (
-      <div className="flex min-h-[70vh] items-center justify-center px-4">
-        <div className="mx-auto max-w-lg rounded-xl border border-border bg-surface px-8 py-10 text-center">
-          <div className="text-[11px] font-semibold uppercase tracking-widest text-orange-600/60">Setup Required</div>
-          <div className="mt-3 text-xl font-bold text-gray-900">Connect ESPN Credentials</div>
-        </div>
-      </div>
-    );
+    return <div className="flex min-h-[70vh] items-center justify-center px-4"><EspnAuthRequired /></div>;
   }
   if (error) {
     return (
@@ -109,7 +103,7 @@ export default function WaiverActivityPage() {
               </tr>
             </thead>
             <tbody>
-              {teamChurn.map((t, i) => (
+              {teamChurn.map((t) => (
                 <tr key={t.teamId} className="border-b border-border/50">
                   <td className="px-3 py-2">
                     <span className="text-[12px] font-medium text-slate-700">{t.teamName}</span>

--- a/web/src/app/strategy/page.tsx
+++ b/web/src/app/strategy/page.tsx
@@ -2,13 +2,13 @@
 
 import { useState, useEffect, useMemo } from "react";
 import type { Player } from "@/lib/data";
+import { sanitizeNum } from "@/lib/sanitize";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 const MY_PICK = 3;   // Luke's draft position (1-indexed)
 const TEAM_COUNT = 10;
 const TOTAL_ROUNDS = 24;
-const DRAFT_ORDER = ["Zach", "Ricky", "Luke", "Roger", "Ethan", "Fitzy", "Dan", "Tim", "JB", "Joel"];
 const MY_NAME = "Luke";
 
 // Category weights (from league history)
@@ -69,9 +69,6 @@ interface ZScorePlayer {
   onTeamId: number;
 }
 
-function safeNum(val: number): number {
-  return Number.isFinite(val) ? val : 0;
-}
 
 export default function StrategyPage() {
   const [players, setPlayers] = useState<Player[]>([]);
@@ -448,7 +445,7 @@ export default function StrategyPage() {
             const adpEntry = espnData[pick.playerName];
             const adp = adpEntry?.adp;
             const overallPick = pick.pick;
-            const farValue = zp ? safeNum(zp.far) : 0;
+            const farValue = zp ? sanitizeNum(zp.far) : 0;
             const adpDiff = adp != null ? Math.round(adp - overallPick) : null;
             let grade: string;
             let gradeColor: string;


### PR DESCRIPTION
## Summary
- Resolve all 13 ESLint errors (setState in useEffect, component created during render, useMemo deps, explicit any)
- Replace 6 hardcoded category order arrays with `ALL_CATS_BY_WEIGHT` import from `category-weights.ts`
- Replace 4 duplicate `safeNum`/`safeDivide` implementations with imports from `lib/sanitize.ts`
- Replace 3 inline ESPN auth error UIs with the `EspnAuthRequired` component
- Add missing "Starts" nav link to GM layout
- Remove unused variables, imports, and dead code across 10 files

## Test plan
- [x] `npx eslint src/`: 0 errors (down from 13)
- [x] `npx tsc --noEmit`: passes with no errors
- [x] `npx vitest run`: 190 tests pass (15 test files)