### PR TITLE
Add 10 new GM features

### DIFF
--- a/.claude/commands/gm-advice.md
+++ b/.claude/commands/gm-advice.md
@@ -68,3 +68,14 @@ git add web/public/gm-advice.json
 git commit -s -m "Update GM advice"
 git push origin main
 ```
+
+## Weekly Auto-Refresh
+
+Run `/gm-advice` at least once per matchup week (Monday or Tuesday) to keep recommendations current. The advice JSON is consumed by the GM dashboard and Daily Actions page, so stale data degrades multiple views.
+
+**Recommended cadence:**
+- Monday morning: full refresh with new matchup opponent data
+- Mid-week (Wednesday/Thursday): refresh if roster moves were made or matchup is close
+- After any trade or significant waiver claim: immediate refresh
+
+The roster-diagnosis API data drives all three sections. If category rankings shift after streaming pickups or trades, re-running `/gm-advice` ensures the week/month/season bullets reflect reality.

--- a/web/src/app/gm/actions/page.tsx
+++ b/web/src/app/gm/actions/page.tsx
@@ -1,0 +1,484 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { EspnAuthRequired } from "@/components/EspnAuthRequired";
+import { DataFreshness } from "@/components/DataFreshness";
+import {
+  CATEGORY_WEIGHTS,
+  categoryTier,
+  isPunt,
+  LOWER_IS_BETTER,
+} from "@/lib/category-weights";
+
+interface CategoryRanking {
+  cat: string;
+  weight: number;
+  rank: number;
+  value: number;
+  tier: "STRONG" | "MIDDLE" | "WEAK";
+  isPunt: boolean;
+}
+
+interface ActionItem {
+  priority: "HIGH" | "MEDIUM" | "LOW";
+  type: "DROP" | "IMPROVE" | "TRADE" | "STREAM" | "PUNT";
+  message: string;
+}
+
+interface DiagnosisData {
+  teamName: string;
+  categoryRankings: CategoryRanking[];
+  actionItems: ActionItem[];
+  marginToFlip: {
+    cat: string;
+    weight: number;
+    currentRank: number;
+    targetRank: number;
+    gap: number;
+  }[];
+}
+
+interface MatchupCat {
+  cat: string;
+  myValue: number | null;
+  oppValue: number | null;
+  result: "WIN" | "LOSS" | "TIE" | "PENDING";
+}
+
+interface MatchupPlayer {
+  name: string;
+  pos: string;
+  slotLabel: string;
+  slotId: number;
+  injuryStatus: string;
+  proTeam: string;
+  stats: Record<string, number>;
+}
+
+interface MatchupData {
+  matchupEndDate: string | null;
+  myTeamName: string;
+  oppTeamName: string;
+  categories: MatchupCat[];
+  myRoster: MatchupPlayer[];
+}
+
+interface ProbableStart {
+  date: string;
+  pitcherName: string;
+  team: string;
+  opponent: string;
+}
+
+interface ProbablePitchersData {
+  allStarts: ProbableStart[];
+  byPitcher: Record<string, ProbableStart[]>;
+}
+
+interface ZScorePlayer {
+  name: string;
+  pos: string;
+  proTeam: string;
+  onTeamId: number;
+  zScores: Record<string, number>;
+  far: number;
+  seasonStats: Record<string, number>;
+}
+
+interface TeamSchedule {
+  todayOpponent: string | null;
+}
+
+interface DailyAction {
+  type: "lineup" | "stream" | "waiver" | "matchup";
+  priority: number;
+  title: string;
+  detail: string;
+  color: string;
+}
+
+const IL_STATUSES = new Set([
+  "SEVEN_DAY_DL",
+  "TEN_DAY_DL",
+  "FIFTEEN_DAY_DL",
+  "SIXTY_DAY_DL",
+  "OUT",
+]);
+const BENCH_SLOT_ID = 16;
+const BATTER_SLOT_IDS = new Set([0, 1, 2, 3, 4, 5, 6, 7, 8, 12]);
+
+function fmtStat(cat: string, val: number): string {
+  if (!Number.isFinite(val)) return "-";
+  if (cat === "AVG") return val.toFixed(3);
+  if (cat === "ERA" || cat === "WHIP") return val.toFixed(2);
+  return String(Math.round(val));
+}
+
+export default function ActionsPage() {
+  const [diagnosis, setDiagnosis] = useState<DiagnosisData | null>(null);
+  const [matchup, setMatchup] = useState<MatchupData | null>(null);
+  const [probables, setProbables] = useState<ProbablePitchersData | null>(null);
+  const [zPlayers, setZPlayers] = useState<ZScorePlayer[]>([]);
+  const [schedule, setSchedule] = useState<Record<string, TeamSchedule>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchAll = () => {
+    setLoading(true);
+    const today = new Date().toISOString().slice(0, 10);
+    Promise.all([
+      fetch("/api/analysis/roster-diagnosis").then((r) => r.json()),
+      fetch("/api/espn/matchup").then((r) => r.json()),
+      fetch(
+        `/api/mlb/probable-pitchers?startDate=${today}&endDate=${today}`
+      )
+        .then((r) => r.json())
+        .catch(() => null),
+      fetch("/api/analysis/z-scores")
+        .then((r) => r.json())
+        .catch(() => ({ players: [] })),
+      fetch(`/api/mlb/schedule?startDate=${today}&endDate=${today}`)
+        .then((r) => r.json())
+        .catch(() => ({})),
+    ])
+      .then(([diag, mup, pp, zData, sched]) => {
+        if (diag.error) {
+          setError(diag.error);
+          return;
+        }
+        setDiagnosis(diag);
+        if (!mup.error) setMatchup(mup);
+        if (pp && !pp.error) setProbables(pp);
+        setZPlayers(zData.players ?? []);
+        if (!sched.error) setSchedule(sched);
+      })
+      .catch(() => setError("FETCH_FAILED"))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchAll();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const actions = useMemo((): DailyAction[] => {
+    const items: DailyAction[] = [];
+    if (!matchup || !diagnosis) return items;
+
+    const daysLeft = matchup.matchupEndDate
+      ? Math.max(
+          0,
+          Math.ceil(
+            (new Date(matchup.matchupEndDate + "T23:59:59").getTime() -
+              Date.now()) /
+              86400000
+          )
+        )
+      : 7;
+
+    // Lineup: bench batters who have games today
+    const benchBatters = matchup.myRoster.filter(
+      (p) =>
+        p.slotId === BENCH_SLOT_ID &&
+        !IL_STATUSES.has(p.injuryStatus) &&
+        !["SP", "RP"].includes(p.pos)
+    );
+    const benchWithGames = benchBatters.filter(
+      (p) => schedule[p.proTeam]?.todayOpponent
+    );
+    for (const p of benchWithGames) {
+      items.push({
+        type: "lineup",
+        priority: 90,
+        title: `Start ${p.name} (${p.pos}, ${p.proTeam})`,
+        detail: `On bench but has a game today vs ${schedule[p.proTeam]?.todayOpponent}`,
+        color: "text-blue-600",
+      });
+    }
+
+    // Lineup: starters on off days
+    const startersNoGame = matchup.myRoster.filter(
+      (p) =>
+        BATTER_SLOT_IDS.has(p.slotId) &&
+        !IL_STATUSES.has(p.injuryStatus) &&
+        !schedule[p.proTeam]?.todayOpponent
+    );
+    if (startersNoGame.length > 0) {
+      items.push({
+        type: "lineup",
+        priority: 85,
+        title: `${startersNoGame.length} starter${startersNoGame.length > 1 ? "s" : ""} have no game today`,
+        detail: startersNoGame.map((p) => `${p.name} (${p.pos})`).join(", "),
+        color: "text-amber-600",
+      });
+    }
+
+    // Streaming: SPs pitching today from probables
+    if (probables) {
+      const rosteredNames = new Set(matchup.myRoster.map((p) => p.name));
+      const todaysStarts = probables.allStarts.filter(
+        (s) => s.date === new Date().toISOString().slice(0, 10)
+      );
+      const myStartsToday = todaysStarts.filter((s) =>
+        rosteredNames.has(s.pitcherName)
+      );
+      if (myStartsToday.length > 0) {
+        items.push({
+          type: "stream",
+          priority: 80,
+          title: `${myStartsToday.length} SP${myStartsToday.length > 1 ? "s" : ""} pitching today`,
+          detail: myStartsToday
+            .map((s) => `${s.pitcherName} vs ${s.opponent}`)
+            .join(", "),
+          color: "text-purple-600",
+        });
+      }
+
+      // Free agent SPs pitching today
+      const faStartsToday = todaysStarts.filter(
+        (s) => !rosteredNames.has(s.pitcherName)
+      );
+      const faWithZ = faStartsToday
+        .map((s) => {
+          const z = zPlayers.find(
+            (p) => p.name === s.pitcherName && p.onTeamId === 0
+          );
+          return { ...s, far: z?.far ?? 0 };
+        })
+        .filter((s) => s.far > 0)
+        .sort((a, b) => b.far - a.far)
+        .slice(0, 3);
+
+      for (const s of faWithZ) {
+        items.push({
+          type: "stream",
+          priority: 75 + s.far,
+          title: `Stream ${s.pitcherName} (${s.team}) vs ${s.opponent}`,
+          detail: `Free agent SP, FAR ${s.far.toFixed(1)}`,
+          color: "text-emerald-600",
+        });
+      }
+    }
+
+    // Waiver: best FA pickups for weak categories
+    const weakCats = diagnosis.categoryRankings
+      .filter((c) => c.tier === "WEAK" && !c.isPunt)
+      .sort((a, b) => b.weight - a.weight);
+
+    const freeAgents = zPlayers
+      .filter((p) => p.onTeamId === 0 && p.far > 0)
+      .sort((a, b) => b.far - a.far);
+
+    for (const weak of weakCats.slice(0, 2)) {
+      const helpers = freeAgents
+        .filter((p) => (p.zScores[weak.cat] ?? 0) > 0.5)
+        .slice(0, 1);
+      for (const fa of helpers) {
+        const statVal = fa.seasonStats[weak.cat];
+        const statStr =
+          statVal !== undefined ? ` ${fmtStat(weak.cat, statVal)}` : "";
+        items.push({
+          type: "waiver",
+          priority: 70 + (CATEGORY_WEIGHTS[weak.cat] ?? 0) * 100,
+          title: `Pick up ${fa.name} (${fa.pos}, ${fa.proTeam})`,
+          detail: `Improves ${weak.cat} (currently #${weak.rank})${statStr}, FAR ${fa.far.toFixed(1)}`,
+          color: "text-orange-600",
+        });
+      }
+    }
+
+    // Matchup: contested categories
+    const contested = matchup.categories
+      .filter((c) => {
+        if (isPunt(c.cat)) return false;
+        if (c.myValue === null || c.oppValue === null) return false;
+        const lower = LOWER_IS_BETTER.has(c.cat);
+        const gap = lower
+          ? c.oppValue - c.myValue
+          : c.myValue - c.oppValue;
+        const range = Math.max(
+          Math.abs(c.myValue),
+          Math.abs(c.oppValue),
+          1
+        );
+        return Math.abs(gap) / range < 0.15;
+      })
+      .sort(
+        (a, b) =>
+          (CATEGORY_WEIGHTS[b.cat] ?? 0) - (CATEGORY_WEIGHTS[a.cat] ?? 0)
+      )
+      .slice(0, 3);
+
+    for (const c of contested) {
+      const lower = LOWER_IS_BETTER.has(c.cat);
+      const gap =
+        c.myValue !== null && c.oppValue !== null
+          ? lower
+            ? c.oppValue - c.myValue
+            : c.myValue - c.oppValue
+          : 0;
+      items.push({
+        type: "matchup",
+        priority: 60 + (CATEGORY_WEIGHTS[c.cat] ?? 0) * 200,
+        title: `${c.cat} is contested: ${fmtStat(c.cat, c.myValue ?? 0)} vs ${fmtStat(c.cat, c.oppValue ?? 0)}`,
+        detail: `${c.result === "WIN" ? "Leading" : c.result === "LOSS" ? "Trailing" : "Tied"} by ${fmtStat(c.cat, Math.abs(gap))} with ${daysLeft}d left (weight: ${(CATEGORY_WEIGHTS[c.cat] ?? 0).toFixed(3)})`,
+        color:
+          c.result === "WIN"
+            ? "text-emerald-600"
+            : c.result === "LOSS"
+              ? "text-red-600"
+              : "text-amber-600",
+      });
+    }
+
+    // Include high-priority diagnosis actions
+    const highActions = diagnosis.actionItems
+      .filter((a) => a.priority === "HIGH")
+      .slice(0, 2);
+    for (const a of highActions) {
+      items.push({
+        type: a.type === "STREAM" ? "stream" : "waiver",
+        priority: 65,
+        title: a.message,
+        detail: `${a.type} action from roster diagnosis`,
+        color:
+          a.type === "DROP"
+            ? "text-red-600"
+            : a.type === "STREAM"
+              ? "text-purple-600"
+              : "text-blue-600",
+      });
+    }
+
+    items.sort((a, b) => b.priority - a.priority);
+    return items;
+  }, [matchup, diagnosis, probables, zPlayers, schedule]);
+
+  if (loading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <div className="flex items-center gap-3 text-slate-500">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-orange-500 border-t-transparent" />
+          Building action list...
+        </div>
+      </div>
+    );
+  }
+
+  if (
+    error === "ESPN_CREDS_MISSING" ||
+    error === "MY_ESPN_TEAM_ID_MISSING"
+  ) {
+    return (
+      <div className="flex min-h-[70vh] items-center justify-center px-4">
+        <EspnAuthRequired />
+      </div>
+    );
+  }
+
+  if (error || !diagnosis) {
+    return (
+      <div className="flex h-64 flex-col items-center justify-center gap-2">
+        <div className="text-red-600">Failed to load actions</div>
+        <div className="text-[12px] text-slate-600">{error}</div>
+      </div>
+    );
+  }
+
+  const typeIcon: Record<DailyAction["type"], string> = {
+    lineup: "LU",
+    stream: "SP",
+    waiver: "FA",
+    matchup: "MU",
+  };
+
+  const typeBg: Record<DailyAction["type"], string> = {
+    lineup: "bg-blue-100 text-blue-700",
+    stream: "bg-purple-100 text-purple-700",
+    waiver: "bg-orange-100 text-orange-700",
+    matchup: "bg-slate-100 text-slate-700",
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-6">
+      <div className="mb-5 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-lg font-bold text-gray-900">Daily Actions</h1>
+          <span className="text-[12px] text-slate-500">
+            {actions.length} action{actions.length !== 1 ? "s" : ""} for today
+          </span>
+        </div>
+        <DataFreshness onRefresh={fetchAll} loading={loading} />
+      </div>
+
+      {actions.length === 0 && (
+        <div className="rounded-xl border border-border bg-surface px-6 py-12 text-center">
+          <div className="text-[14px] font-medium text-slate-600">
+            No actions for today
+          </div>
+          <div className="mt-1 text-[12px] text-slate-400">
+            Check back when games are scheduled
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        {actions.map((action, i) => (
+          <div
+            key={i}
+            className="rounded-xl border border-border bg-surface px-4 py-3 hover:bg-black/[0.01] transition-colors"
+          >
+            <div className="flex items-start gap-3">
+              <span
+                className={`shrink-0 mt-0.5 rounded px-2 py-1 text-[10px] font-bold ${typeBg[action.type]}`}
+              >
+                {typeIcon[action.type]}
+              </span>
+              <div className="flex-1 min-w-0">
+                <div className={`text-[14px] font-medium ${action.color}`}>
+                  {action.title}
+                </div>
+                <div className="mt-0.5 text-[12px] text-slate-500">
+                  {action.detail}
+                </div>
+              </div>
+              <span className="shrink-0 text-[10px] font-mono text-slate-300 tabular-nums">
+                #{i + 1}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Weak categories summary */}
+      {diagnosis.categoryRankings.some(
+        (c) => c.tier === "WEAK" && !c.isPunt
+      ) && (
+        <div className="mt-6 rounded-xl border border-red-200 bg-red-50/50 px-4 py-3">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-red-600 mb-2">
+            Weak Categories
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {diagnosis.categoryRankings
+              .filter((c) => c.tier === "WEAK" && !c.isPunt)
+              .sort((a, b) => b.weight - a.weight)
+              .map((c) => (
+                <span
+                  key={c.cat}
+                  className="rounded border border-red-200 bg-white px-2 py-1 text-[11px]"
+                >
+                  <span className="font-bold text-red-700">{c.cat}</span>
+                  <span className="ml-1 text-slate-500">
+                    #{c.rank}
+                  </span>
+                  <span className="ml-1 text-[9px] text-slate-400">
+                    w:{c.weight.toFixed(3)}
+                  </span>
+                </span>
+              ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/gm/compare/page.tsx
+++ b/web/src/app/gm/compare/page.tsx
@@ -1,0 +1,532 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { EspnAuthRequired } from "@/components/EspnAuthRequired";
+import {
+  CATEGORY_WEIGHTS,
+  categoryTierClass,
+  isPunt,
+  LOWER_IS_BETTER,
+  BAT_CATS_BY_WEIGHT,
+  PIT_CATS_BY_WEIGHT,
+} from "@/lib/category-weights";
+
+interface PlayerStats {
+  name: string;
+  pos: string;
+  proTeam: string;
+  seasonStats: Record<string, number>;
+  last7Stats: Record<string, number>;
+  last15Stats: Record<string, number>;
+  last30Stats: Record<string, number>;
+}
+
+interface ZScorePlayer {
+  name: string;
+  pos: string;
+  proTeam: string;
+  onTeamId: number;
+  zScores: Record<string, number>;
+  zTotal: number;
+  far: number;
+}
+
+interface CategoryRanking {
+  cat: string;
+  tier: "STRONG" | "MIDDLE" | "WEAK";
+  isPunt: boolean;
+}
+
+interface DiagnosisData {
+  categoryRankings: CategoryRanking[];
+}
+
+const BAT_CATS = ["TB", "HR", "R", "RBI", "H", "SB", "BB", "AVG"];
+const PIT_CATS = ["W", "K", "WHIP", "QS", "ERA", "L", "HD", "SV"];
+
+function fmtStat(cat: string, val: number | undefined): string {
+  if (val === undefined || !Number.isFinite(val)) return "-";
+  if (cat === "AVG") return val.toFixed(3);
+  if (cat === "ERA" || cat === "WHIP") return val.toFixed(2);
+  if (cat === "IP") return val.toFixed(1);
+  return String(Math.round(val));
+}
+
+function zColorClass(z: number): string {
+  if (z >= 1.5) return "text-emerald-700 font-bold";
+  if (z >= 0.5) return "text-emerald-600";
+  if (z >= 0) return "text-slate-600";
+  return "text-red-600";
+}
+
+export default function ComparePage() {
+  const [allPlayers, setAllPlayers] = useState<string[]>([]);
+  const [statsMap, setStatsMap] = useState<Map<string, PlayerStats>>(
+    new Map()
+  );
+  const [zByName, setZByName] = useState<Map<string, ZScorePlayer>>(
+    new Map()
+  );
+  const [weakCats, setWeakCats] = useState<Set<string>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const [playerA, setPlayerA] = useState<string>("");
+  const [playerB, setPlayerB] = useState<string>("");
+  const [searchA, setSearchA] = useState("");
+  const [searchB, setSearchB] = useState("");
+
+  useEffect(() => {
+    Promise.all([
+      fetch("/api/espn/player-stats")
+        .then((r) => r.json())
+        .catch(() => ({ players: [] })),
+      fetch("/api/analysis/z-scores")
+        .then((r) => r.json())
+        .catch(() => ({ players: [] })),
+      fetch("/api/analysis/roster-diagnosis")
+        .then((r) => r.json())
+        .catch(() => null),
+    ])
+      .then(([statsData, zData, diag]) => {
+        if (statsData.error) {
+          setError(statsData.error);
+          return;
+        }
+        const players: PlayerStats[] = statsData.players ?? [];
+        const sm = new Map<string, PlayerStats>();
+        const names: string[] = [];
+        players.forEach((p) => {
+          sm.set(p.name, p);
+          names.push(p.name);
+        });
+        setStatsMap(sm);
+
+        const zm = new Map<string, ZScorePlayer>();
+        const zp: ZScorePlayer[] = zData.players ?? [];
+        zp.forEach((p) => {
+          zm.set(p.name, p);
+          if (!sm.has(p.name)) names.push(p.name);
+        });
+        setZByName(zm);
+        setAllPlayers(names.sort());
+
+        if (diag && !diag.error) {
+          const weak = new Set<string>();
+          for (const cr of diag.categoryRankings) {
+            if (cr.tier === "WEAK" && !cr.isPunt) weak.add(cr.cat);
+          }
+          setWeakCats(weak);
+        }
+      })
+      .catch(() => setError("FETCH_FAILED"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const filteredA = useMemo(
+    () =>
+      searchA
+        ? allPlayers
+            .filter((n) =>
+              n.toLowerCase().includes(searchA.toLowerCase())
+            )
+            .slice(0, 15)
+        : [],
+    [allPlayers, searchA]
+  );
+
+  const filteredB = useMemo(
+    () =>
+      searchB
+        ? allPlayers
+            .filter((n) =>
+              n.toLowerCase().includes(searchB.toLowerCase())
+            )
+            .slice(0, 15)
+        : [],
+    [allPlayers, searchB]
+  );
+
+  const pA = statsMap.get(playerA) ?? null;
+  const pB = statsMap.get(playerB) ?? null;
+  const zA = zByName.get(playerA) ?? null;
+  const zB = zByName.get(playerB) ?? null;
+
+  // Determine which cats to show
+  const isPitcherA = pA?.pos === "SP" || pA?.pos === "RP" || zA?.pos === "SP" || zA?.pos === "RP";
+  const isPitcherB = pB?.pos === "SP" || pB?.pos === "RP" || zB?.pos === "SP" || zB?.pos === "RP";
+  const showBat = !isPitcherA || !isPitcherB;
+  const showPit = isPitcherA || isPitcherB;
+
+  // Verdict
+  const verdict = useMemo(() => {
+    if (!playerA || !playerB || !zA || !zB) return null;
+
+    const aHelps: { cat: string; diff: number; weight: number }[] = [];
+    const bHelps: { cat: string; diff: number; weight: number }[] = [];
+
+    for (const cat of [...BAT_CATS, ...PIT_CATS]) {
+      if (isPunt(cat)) continue;
+      const aZ = zA.zScores[cat] ?? 0;
+      const bZ = zB.zScores[cat] ?? 0;
+      if (!weakCats.has(cat)) continue;
+
+      if (aZ > bZ + 0.1) {
+        aHelps.push({ cat, diff: aZ - bZ, weight: CATEGORY_WEIGHTS[cat] ?? 0 });
+      } else if (bZ > aZ + 0.1) {
+        bHelps.push({ cat, diff: bZ - aZ, weight: CATEGORY_WEIGHTS[cat] ?? 0 });
+      }
+    }
+
+    const aWeightedImpact = aHelps.reduce(
+      (sum, c) => sum + c.diff * c.weight,
+      0
+    );
+    const bWeightedImpact = bHelps.reduce(
+      (sum, c) => sum + c.diff * c.weight,
+      0
+    );
+
+    return {
+      aHelps,
+      bHelps,
+      aWeightedImpact,
+      bWeightedImpact,
+      pick: aWeightedImpact > bWeightedImpact ? "A" : bWeightedImpact > aWeightedImpact ? "B" : "TIE",
+    };
+  }, [playerA, playerB, zA, zB, weakCats]);
+
+  if (loading)
+    return (
+      <div className="flex h-64 items-center justify-center text-slate-500">
+        Loading player data...
+      </div>
+    );
+  if (error === "ESPN_CREDS_MISSING")
+    return (
+      <div className="flex min-h-[70vh] items-center justify-center px-4">
+        <EspnAuthRequired />
+      </div>
+    );
+  if (error)
+    return (
+      <div className="flex h-64 flex-col items-center justify-center gap-2">
+        <div className="text-red-600">Failed to load</div>
+        <div className="text-[12px] text-slate-500">{error}</div>
+      </div>
+    );
+
+  const PlayerSelector = ({
+    label,
+    selected,
+    setSelected,
+    search,
+    setSearch,
+    filtered,
+    color,
+  }: {
+    label: string;
+    selected: string;
+    setSelected: (n: string) => void;
+    search: string;
+    setSearch: (s: string) => void;
+    filtered: string[];
+    color: string;
+  }) => (
+    <div className="flex-1">
+      <label className="text-[10px] font-semibold uppercase tracking-wider text-slate-500 block mb-1">
+        {label}
+      </label>
+      {selected ? (
+        <div
+          className={`flex items-center gap-2 rounded border px-3 py-2 ${color}`}
+        >
+          <span className="text-[14px] font-medium text-slate-700 flex-1">
+            {selected}
+          </span>
+          <span className="text-[10px] text-slate-500">
+            {statsMap.get(selected)?.pos ?? zByName.get(selected)?.pos ?? ""}
+          </span>
+          <button
+            onClick={() => setSelected("")}
+            className="text-slate-400 hover:text-red-600 text-[12px] font-bold"
+          >
+            x
+          </button>
+        </div>
+      ) : (
+        <div className="relative">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search players..."
+            className="w-full rounded border border-border bg-background px-3 py-2 text-[13px] text-slate-700 outline-none placeholder:text-slate-400"
+          />
+          {filtered.length > 0 && (
+            <div className="absolute top-full left-0 right-0 z-10 mt-1 max-h-[240px] overflow-y-auto rounded border border-border bg-surface shadow-lg">
+              {filtered.map((name) => (
+                <button
+                  key={name}
+                  onClick={() => {
+                    setSelected(name);
+                    setSearch("");
+                  }}
+                  className="flex w-full items-center justify-between px-3 py-2 text-left hover:bg-black/[0.03] border-b border-border"
+                >
+                  <span className="text-[12px] text-slate-700">{name}</span>
+                  <span className="text-[10px] text-slate-500">
+                    {statsMap.get(name)?.pos ??
+                      zByName.get(name)?.pos ??
+                      ""}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-6">
+      <div className="mb-5">
+        <h1 className="text-lg font-bold text-gray-900">
+          Player Comparison
+        </h1>
+        <span className="text-[12px] text-slate-500">
+          Compare any two players side by side
+        </span>
+      </div>
+
+      {/* Player selectors */}
+      <div className="mb-6 flex gap-4">
+        <PlayerSelector
+          label="Player A"
+          selected={playerA}
+          setSelected={setPlayerA}
+          search={searchA}
+          setSearch={setSearchA}
+          filtered={filteredA}
+          color="border-blue-300 bg-blue-50"
+        />
+        <div className="flex items-end pb-2 text-slate-400 font-bold">
+          vs
+        </div>
+        <PlayerSelector
+          label="Player B"
+          selected={playerB}
+          setSelected={setPlayerB}
+          search={searchB}
+          setSearch={setSearchB}
+          filtered={filteredB}
+          color="border-purple-300 bg-purple-50"
+        />
+      </div>
+
+      {/* Comparison */}
+      {playerA && playerB && (
+        <>
+          {/* Z-score comparison */}
+          {zA && zB && (
+            <div className="mb-6 rounded-xl border border-border bg-surface overflow-hidden">
+              <div className="border-b border-border px-4 py-2.5 flex items-center justify-between">
+                <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-600">
+                  Z-Score Comparison
+                </span>
+                <div className="flex items-center gap-4 text-[11px] font-mono tabular-nums">
+                  <span className="text-blue-600">
+                    FAR {zA.far.toFixed(1)}
+                  </span>
+                  <span className="text-slate-400">vs</span>
+                  <span className="text-purple-600">
+                    FAR {zB.far.toFixed(1)}
+                  </span>
+                </div>
+              </div>
+
+              {(showBat
+                ? [{ label: "Batting", cats: BAT_CATS_BY_WEIGHT }]
+                : []
+              )
+                .concat(
+                  showPit
+                    ? [{ label: "Pitching", cats: PIT_CATS_BY_WEIGHT }]
+                    : []
+                )
+                .map(({ label, cats }) => (
+                  <div key={label}>
+                    <div className="px-4 py-1.5 text-[9px] font-bold uppercase tracking-widest text-slate-400 bg-black/[0.02]">
+                      {label}
+                    </div>
+                    <div className="grid grid-cols-4 sm:grid-cols-8">
+                      {cats.map((cat) => {
+                        const aZ = zA.zScores[cat] ?? 0;
+                        const bZ = zB.zScores[cat] ?? 0;
+                        const isWeak = weakCats.has(cat);
+                        const aWins = LOWER_IS_BETTER.has(cat)
+                          ? aZ < bZ
+                          : aZ > bZ;
+                        const bWins = !aWins && aZ !== bZ;
+                        return (
+                          <div
+                            key={cat}
+                            className={`border-r border-b border-border last:border-r-0 px-2 py-2.5 text-center ${
+                              isWeak ? "bg-amber-50/50" : ""
+                            }${isPunt(cat) ? " opacity-50" : ""}`}
+                          >
+                            <div
+                              className={`text-[10px] ${categoryTierClass(cat)} ${isWeak ? "text-amber-600" : ""}`}
+                            >
+                              {cat}
+                              {isWeak ? "*" : ""}
+                            </div>
+                            <div
+                              className={`mt-1 text-[12px] font-mono tabular-nums ${aWins ? "text-blue-600 font-bold" : "text-slate-500"}`}
+                            >
+                              {aZ >= 0 ? "+" : ""}
+                              {aZ.toFixed(1)}
+                            </div>
+                            <div
+                              className={`text-[12px] font-mono tabular-nums ${bWins ? "text-purple-600 font-bold" : "text-slate-500"}`}
+                            >
+                              {bZ >= 0 ? "+" : ""}
+                              {bZ.toFixed(1)}
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))}
+
+              {weakCats.size > 0 && (
+                <div className="px-4 py-2 border-t border-border text-[10px] text-amber-600 bg-amber-50/30">
+                  * Your weak categories
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Season stats comparison */}
+          {pA && pB && (
+            <div className="mb-6 rounded-xl border border-border bg-surface overflow-hidden">
+              <div className="border-b border-border px-4 py-2.5">
+                <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-600">
+                  Season Stats
+                </span>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full text-[11px]">
+                  <thead>
+                    <tr className="border-b border-border bg-slate-50 text-[9px] font-semibold uppercase tracking-wider text-slate-500">
+                      <th className="px-3 py-2 text-left">Stat</th>
+                      <th className="px-3 py-2 text-right text-blue-600">
+                        {playerA.split(" ").pop()}
+                      </th>
+                      <th className="px-3 py-2 text-right text-purple-600">
+                        {playerB.split(" ").pop()}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {(showBat ? BAT_CATS : PIT_CATS).map((cat) => {
+                      const aVal = pA.seasonStats[cat];
+                      const bVal = pB.seasonStats[cat];
+                      const lower = LOWER_IS_BETTER.has(cat);
+                      const aWins =
+                        aVal !== undefined &&
+                        bVal !== undefined &&
+                        (lower ? aVal < bVal : aVal > bVal);
+                      const bWins =
+                        aVal !== undefined &&
+                        bVal !== undefined &&
+                        (lower ? bVal < aVal : bVal > aVal);
+                      return (
+                        <tr key={cat} className="border-b border-border">
+                          <td
+                            className={`px-3 py-1.5 ${categoryTierClass(cat)}`}
+                          >
+                            {cat}
+                          </td>
+                          <td
+                            className={`px-3 py-1.5 text-right font-mono tabular-nums ${aWins ? "text-blue-600 font-bold" : "text-slate-600"}`}
+                          >
+                            {fmtStat(cat, aVal)}
+                          </td>
+                          <td
+                            className={`px-3 py-1.5 text-right font-mono tabular-nums ${bWins ? "text-purple-600 font-bold" : "text-slate-600"}`}
+                          >
+                            {fmtStat(cat, bVal)}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {/* Verdict */}
+          {verdict && (
+            <div
+              className={`rounded-xl border px-4 py-4 ${
+                verdict.pick === "A"
+                  ? "border-blue-300 bg-blue-50/50"
+                  : verdict.pick === "B"
+                    ? "border-purple-300 bg-purple-50/50"
+                    : "border-slate-300 bg-slate-50"
+              }`}
+            >
+              <div className="text-[10px] font-semibold uppercase tracking-wider text-slate-600 mb-2">
+                Verdict
+              </div>
+              {verdict.pick === "TIE" ? (
+                <div className="text-[14px] font-medium text-slate-600">
+                  Even impact on your weak categories
+                </div>
+              ) : (
+                <div>
+                  <div
+                    className={`text-[14px] font-bold ${verdict.pick === "A" ? "text-blue-600" : "text-purple-600"}`}
+                  >
+                    Pick {verdict.pick === "A" ? playerA : playerB}
+                    <span className="ml-1 text-[12px] font-normal text-slate-500">
+                      (higher weighted impact on weak categories)
+                    </span>
+                  </div>
+                  <div className="mt-2 flex flex-wrap gap-2 text-[11px]">
+                    {(verdict.pick === "A"
+                      ? verdict.aHelps
+                      : verdict.bHelps
+                    ).map((c) => (
+                      <span
+                        key={c.cat}
+                        className="rounded bg-white border border-current px-2 py-0.5 text-emerald-600"
+                      >
+                        {c.cat} +{c.diff.toFixed(1)}z
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </>
+      )}
+
+      {(!playerA || !playerB) && (
+        <div className="rounded-xl border border-border bg-surface px-6 py-12 text-center">
+          <div className="text-[14px] font-medium text-slate-600">
+            Select two players to compare
+          </div>
+          <div className="mt-1 text-[12px] text-slate-400">
+            See side-by-side stats, z-scores, and which player helps your team more
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/gm/layout.tsx
+++ b/web/src/app/gm/layout.tsx
@@ -3,6 +3,7 @@
 import { SectionNav } from "@/components/SectionNav";
 
 const SUB_LINKS = [
+  { href: "/gm/actions", label: "Actions" },
   { href: "/gm/today", label: "Today" },
   { href: "/gm/matchup", label: "Matchup" },
   { href: "/gm/matchup-tracker", label: "Matchup Tracker" },
@@ -12,12 +13,19 @@ const SUB_LINKS = [
   { href: "/gm/bullpen", label: "Bullpen" },
   { href: "/gm/starts", label: "Starts" },
   { href: "/gm/sp-scout", label: "SP Scout" },
+  { href: "/gm/next-week", label: "Next Week" },
   { href: "/gm/schedule-outlook", label: "Timeline" },
+  { href: "/gm/pace", label: "Pace" },
   { href: "/gm/season-log", label: "Season Log" },
   { href: "/gm/category-breakdown", label: "Category Breakdown" },
   { href: "/gm/h2h", label: "Team H2H" },
   { href: "/gm/free-agents", label: "Free Agents" },
+  { href: "/gm/waiver-plan", label: "Waiver Plan" },
+  { href: "/gm/compare", label: "Compare" },
   { href: "/gm/trade", label: "Trade Room" },
+  { href: "/gm/trade-simulator", label: "Trade Sim" },
+  { href: "/gm/quick", label: "Quick View" },
+  { href: "/gm/notes", label: "Notes" },
   { href: "/draft", label: "Draft" },
 ];
 

--- a/web/src/app/gm/matchup/page.tsx
+++ b/web/src/app/gm/matchup/page.tsx
@@ -602,6 +602,68 @@ export default function MatchupPage() {
         </div>
       </div>
 
+      {/* Live Scoreboard */}
+      <div className="mb-4 rounded-xl border border-border bg-surface overflow-hidden">
+        <div className="border-b border-border px-4 py-2.5 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-600">Live Scoreboard</span>
+            <span className="text-[14px] font-bold tabular-nums">
+              <span className={myWinCount > oppWinCount ? "text-emerald-600" : myWinCount < oppWinCount ? "text-red-600" : "text-slate-600"}>
+                {myWinCount > oppWinCount ? "Winning" : myWinCount < oppWinCount ? "Losing" : "Tied"} {myWinCount}-{oppWinCount}{myTieCount > 0 ? `-${myTieCount}` : ""}
+              </span>
+            </span>
+          </div>
+          {winProbs && (() => {
+            const catWinProbs = Object.values(winProbs);
+            const avgWinProb = catWinProbs.length > 0
+              ? Math.round(catWinProbs.reduce((s, v) => s + v, 0) / catWinProbs.length)
+              : 50;
+            return (
+              <span className={`text-[14px] font-bold tabular-nums ${
+                avgWinProb > 55 ? "text-emerald-600" : avgWinProb < 45 ? "text-red-600" : "text-orange-600"
+              }`}>
+                {avgWinProb}% win prob
+              </span>
+            );
+          })()}
+        </div>
+        <div className="px-4 py-3 grid grid-cols-2 sm:grid-cols-4 gap-2">
+          {data.categories.map((c) => {
+            const myVal = c.myValue ?? 0;
+            const oppVal = c.oppValue ?? 0;
+            const lower = LOWER_IS_BETTER.has(c.cat);
+            const gap = lower ? oppVal - myVal : myVal - oppVal;
+            const range = Math.max(Math.abs(myVal), Math.abs(oppVal), 1);
+            const isContested = !isPunt(c.cat) && Math.abs(gap) / range < 0.10;
+            const canPush = !isPunt(c.cat) && c.result === "LOSS" && winProbs && (winProbs[c.cat] ?? 0) > 33;
+            return (
+              <div key={c.cat} className={`rounded-lg px-3 py-2 text-[12px] ${
+                isContested ? "bg-yellow-50 border border-yellow-300" :
+                canPush ? "bg-blue-50 border border-blue-200" :
+                "border border-transparent"
+              }`}>
+                <div className="flex items-center justify-between">
+                  <span className={`font-bold ${catResultColor(c.result)}`}>{c.cat}</span>
+                  <span className={`text-[9px] font-bold ${catResultColor(c.result)}`}>{c.result}</span>
+                </div>
+                <div className="mt-0.5 font-mono tabular-nums">
+                  <span className="text-slate-700">{fmtCat(c.cat, c.myValue)}</span>
+                  <span className="text-slate-400"> vs </span>
+                  <span className="text-slate-500">{fmtCat(c.cat, c.oppValue)}</span>
+                  {c.result !== "PENDING" && (
+                    <span className={`ml-1 text-[10px] font-bold ${gap > 0 ? "text-emerald-600" : gap < 0 ? "text-red-600" : "text-slate-400"}`}>
+                      ({gap > 0 ? "+" : ""}{c.cat === "AVG" || c.cat === "ERA" || c.cat === "WHIP" ? gap.toFixed(3) : Math.round(gap)})
+                    </span>
+                  )}
+                </div>
+                {isContested && <div className="text-[9px] font-bold text-yellow-600 mt-0.5">CONTESTED</div>}
+                {canPush && !isContested && <div className="text-[9px] font-bold text-blue-600 mt-0.5">PUSHABLE</div>}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
       {/* Starts counter bar */}
       {startsCounts && (
         <div className="mb-4 flex items-center justify-center gap-4 rounded-lg border border-border bg-surface px-4 py-2">

--- a/web/src/app/gm/next-week/page.tsx
+++ b/web/src/app/gm/next-week/page.tsx
@@ -1,0 +1,507 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { EspnAuthRequired } from "@/components/EspnAuthRequired";
+
+interface StartsTeamPitcher {
+  name: string;
+  pos: string;
+  proTeam: string;
+  onIL: boolean;
+}
+
+interface StartsTeam {
+  teamId: number;
+  teamName: string;
+  pitchers: StartsTeamPitcher[];
+}
+
+interface StartsData {
+  myTeamId: number;
+  nextDates: { start: string; end: string } | null;
+  teams: StartsTeam[];
+  rosteredPitchers: string[];
+}
+
+interface ProbableStart {
+  date: string;
+  pitcherName: string;
+  team: string;
+  opponent: string;
+}
+
+interface ProbablePitchersData {
+  byPitcher: Record<string, ProbableStart[]>;
+  allStarts: ProbableStart[];
+}
+
+interface LiveTeam {
+  teamId: number;
+  teamName: string;
+  ranks: Record<string, number>;
+}
+
+interface ScheduleDay {
+  date: string;
+  games: number;
+}
+
+function fmtDate(d: string): string {
+  return new Date(d + "T12:00:00").toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function fmtDateRange(start: string, end: string): string {
+  const s = new Date(start + "T12:00:00").toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+  const e = new Date(end + "T12:00:00").toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+  return `${s} to ${e}`;
+}
+
+function findStarts(
+  pitcherName: string,
+  probables: ProbablePitchersData | null
+): ProbableStart[] {
+  if (!probables) return [];
+  if (probables.byPitcher[pitcherName]) return probables.byPitcher[pitcherName];
+  const lower = pitcherName.toLowerCase();
+  for (const [name, starts] of Object.entries(probables.byPitcher)) {
+    if (name.toLowerCase() === lower) return starts;
+  }
+  const lastName = pitcherName
+    .split(" ")
+    .pop()
+    ?.replace(/[.,]|Jr|Sr|III|II$/g, "")
+    .trim()
+    .toLowerCase();
+  if (lastName) {
+    for (const [name, starts] of Object.entries(probables.byPitcher)) {
+      const probLast = name
+        .split(" ")
+        .pop()
+        ?.replace(/[.,]|Jr|Sr|III|II$/g, "")
+        .trim()
+        .toLowerCase();
+      if (probLast === lastName) return starts;
+    }
+  }
+  return [];
+}
+
+export default function NextWeekPage() {
+  const [startsData, setStartsData] = useState<StartsData | null>(null);
+  const [probables, setProbables] = useState<ProbablePitchersData | null>(null);
+  const [leagueTeams, setLeagueTeams] = useState<LiveTeam[]>([]);
+  const [nextOppId, setNextOppId] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/espn/starts")
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.error) {
+          setError(data.error);
+          setLoading(false);
+          return;
+        }
+        setStartsData(data);
+
+        const fetches: Promise<unknown>[] = [];
+
+        if (data.nextDates) {
+          fetches.push(
+            fetch(
+              `/api/mlb/probable-pitchers?startDate=${data.nextDates.start}&endDate=${data.nextDates.end}`
+            )
+              .then((r) => r.json())
+              .catch(() => null)
+          );
+        } else {
+          fetches.push(Promise.resolve(null));
+        }
+
+        fetches.push(
+          fetch("/api/espn/league-stats?scope=season")
+            .then((r) => r.json())
+            .catch(() => ({ teams: [] }))
+        );
+
+        fetches.push(
+          fetch("/api/espn/schedule")
+            .then((r) => r.json())
+            .catch(() => null)
+        );
+
+        return Promise.all(fetches).then(([pp, league, sched]) => {
+          type WithError = { error?: string };
+          const p = pp as (ProbablePitchersData & WithError) | null;
+          const l = league as { teams?: LiveTeam[] } & WithError;
+          if (p && !p.error) setProbables(p);
+          if (l.teams) setLeagueTeams(l.teams);
+
+          // Try to find next week's opponent from schedule
+          const schedData = sched as { error?: string; nextOpponent?: { teamId: number } } | null;
+          if (schedData && !schedData.error && schedData.nextOpponent) {
+            setNextOppId(schedData.nextOpponent.teamId);
+          }
+        });
+      })
+      .catch(() => setError("FETCH_FAILED"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const nextDates = startsData?.nextDates;
+
+  // My team double starters
+  const myTeam = useMemo(
+    () => startsData?.teams.find((t) => t.teamId === startsData.myTeamId),
+    [startsData]
+  );
+
+  type PitcherWithStarts = StartsTeamPitcher & {
+    starts: ProbableStart[];
+    startCount: number;
+  };
+
+  const myDoubleStarters = useMemo((): PitcherWithStarts[] => {
+    if (!myTeam || !probables) return [];
+    return myTeam.pitchers
+      .filter((p) => p.pos === "SP" && !p.onIL)
+      .map((p) => {
+        const starts = findStarts(p.name, probables);
+        return { ...p, starts, startCount: starts.length };
+      })
+      .filter((p) => p.startCount >= 2)
+      .sort((a, b) => b.startCount - a.startCount);
+  }, [myTeam, probables]);
+
+  // FA double starters
+  const rosteredSet = useMemo(
+    () => new Set(startsData?.rosteredPitchers ?? []),
+    [startsData]
+  );
+
+  const faDoubleStarters = useMemo(() => {
+    if (!probables) return [];
+    return Object.entries(probables.byPitcher)
+      .filter(([, starts]) => starts.length >= 2)
+      .filter(([name]) => !rosteredSet.has(name))
+      .map(([name, starts]) => ({
+        name,
+        starts,
+        team: starts[0]?.team ?? "",
+      }))
+      .sort((a, b) => b.starts.length - a.starts.length);
+  }, [probables, rosteredSet]);
+
+  // Schedule density (games per day next week)
+  const scheduleDensity = useMemo((): ScheduleDay[] => {
+    if (!probables || !nextDates) return [];
+    const dayCounts: Record<string, number> = {};
+
+    for (const start of probables.allStarts) {
+      dayCounts[start.date] = (dayCounts[start.date] ?? 0) + 1;
+    }
+
+    const days: ScheduleDay[] = [];
+    const d = new Date(nextDates.start + "T12:00:00");
+    const end = new Date(nextDates.end + "T12:00:00");
+    while (d <= end) {
+      const dateStr = d.toISOString().slice(0, 10);
+      days.push({ date: dateStr, games: dayCounts[dateStr] ?? 0 });
+      d.setDate(d.getDate() + 1);
+    }
+    return days;
+  }, [probables, nextDates]);
+
+  // Opponent info
+  const oppTeam = useMemo(() => {
+    if (!nextOppId) return null;
+    return leagueTeams.find((t) => t.teamId === nextOppId) ?? null;
+  }, [leagueTeams, nextOppId]);
+
+  const oppWeakCats = useMemo(() => {
+    if (!oppTeam) return [];
+    return Object.entries(oppTeam.ranks)
+      .filter(([, r]) => r >= 8)
+      .sort(([, a], [, b]) => b - a)
+      .map(([cat, rank]) => ({ cat, rank }));
+  }, [oppTeam]);
+
+  const oppStrongCats = useMemo(() => {
+    if (!oppTeam) return [];
+    return Object.entries(oppTeam.ranks)
+      .filter(([, r]) => r <= 3)
+      .sort(([, a], [, b]) => a - b)
+      .map(([cat, rank]) => ({ cat, rank }));
+  }, [oppTeam]);
+
+  if (loading)
+    return (
+      <div className="flex h-64 items-center justify-center text-slate-500">
+        Loading next week...
+      </div>
+    );
+  if (
+    error === "ESPN_CREDS_MISSING" ||
+    error === "MY_ESPN_TEAM_ID_MISSING"
+  )
+    return (
+      <div className="flex min-h-[70vh] items-center justify-center px-4">
+        <EspnAuthRequired />
+      </div>
+    );
+  if (error || !startsData)
+    return (
+      <div className="flex h-64 flex-col items-center justify-center gap-2">
+        <div className="text-red-600">Failed to load</div>
+        <div className="text-[12px] text-slate-500">{error}</div>
+      </div>
+    );
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-6">
+      <div className="mb-5">
+        <h1 className="text-lg font-bold text-gray-900">Next Week Lookahead</h1>
+        {nextDates && (
+          <span className="text-[12px] text-slate-500">
+            {fmtDateRange(nextDates.start, nextDates.end)}
+          </span>
+        )}
+      </div>
+
+      {/* Opponent scouting */}
+      {oppTeam && (
+        <div className="mb-6 rounded-xl border border-border bg-surface overflow-hidden">
+          <div className="border-b border-border px-4 py-2.5">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-600">
+              Next Opponent
+            </span>
+            <span className="ml-2 text-[14px] font-bold text-slate-700">
+              {oppTeam.teamName}
+            </span>
+          </div>
+          <div className="px-4 py-3 grid gap-4 sm:grid-cols-2">
+            {oppWeakCats.length > 0 && (
+              <div>
+                <div className="text-[10px] font-semibold text-emerald-600 uppercase tracking-wider mb-2">
+                  Their Weaknesses (exploit these)
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {oppWeakCats.map(({ cat, rank }) => (
+                    <span
+                      key={cat}
+                      className="rounded bg-emerald-50 border border-emerald-200 px-2 py-1 text-[11px]"
+                    >
+                      <span className="font-bold text-emerald-700">{cat}</span>
+                      <span className="ml-1 text-slate-500">#{rank}</span>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+            {oppStrongCats.length > 0 && (
+              <div>
+                <div className="text-[10px] font-semibold text-red-600 uppercase tracking-wider mb-2">
+                  Their Strengths (avoid these)
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {oppStrongCats.map(({ cat, rank }) => (
+                    <span
+                      key={cat}
+                      className="rounded bg-red-50 border border-red-200 px-2 py-1 text-[11px]"
+                    >
+                      <span className="font-bold text-red-700">{cat}</span>
+                      <span className="ml-1 text-slate-500">#{rank}</span>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Schedule density */}
+      {scheduleDensity.length > 0 && (
+        <div className="mb-6 rounded-xl border border-border bg-surface overflow-hidden">
+          <div className="border-b border-border px-4 py-2.5">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-600">
+              Schedule Density
+            </span>
+          </div>
+          <div className="px-4 py-3">
+            <div className="flex gap-2">
+              {scheduleDensity.map((d) => {
+                const maxGames = Math.max(
+                  ...scheduleDensity.map((x) => x.games),
+                  1
+                );
+                const pct = (d.games / maxGames) * 100;
+                const isBusiest = d.games === maxGames;
+                const isLightest =
+                  d.games ===
+                  Math.min(...scheduleDensity.map((x) => x.games));
+                return (
+                  <div key={d.date} className="flex-1 text-center">
+                    <div className="text-[10px] font-bold text-slate-500">
+                      {new Date(d.date + "T12:00:00").toLocaleDateString(
+                        "en-US",
+                        { weekday: "short" }
+                      )}
+                    </div>
+                    <div className="mt-1 mx-auto w-8 h-16 bg-slate-100 rounded relative overflow-hidden">
+                      <div
+                        className={`absolute bottom-0 w-full rounded transition-all ${
+                          isBusiest
+                            ? "bg-emerald-400"
+                            : isLightest
+                              ? "bg-slate-300"
+                              : "bg-blue-300"
+                        }`}
+                        style={{ height: `${pct}%` }}
+                      />
+                    </div>
+                    <div
+                      className={`mt-1 text-[12px] font-bold tabular-nums ${
+                        isBusiest
+                          ? "text-emerald-600"
+                          : isLightest
+                            ? "text-slate-400"
+                            : "text-slate-600"
+                      }`}
+                    >
+                      {d.games}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+            <div className="mt-2 text-[10px] text-slate-400 text-center">
+              Games with probable starters announced
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* My team double starters */}
+      {myDoubleStarters.length > 0 && (
+        <div className="mb-6 rounded-xl border border-orange-300 bg-surface overflow-hidden">
+          <div className="border-b border-orange-300 px-4 py-2.5 flex items-center justify-between">
+            <div>
+              <span className="text-[10px] font-semibold uppercase tracking-wider text-orange-600">
+                Your Double Starters
+              </span>
+              <span className="ml-2 text-[10px] text-slate-500">
+                SPs with 2+ starts next week
+              </span>
+            </div>
+            <span className="text-[14px] font-bold tabular-nums text-orange-600">
+              {myDoubleStarters.length}
+            </span>
+          </div>
+          <div className="divide-y divide-border">
+            {myDoubleStarters.map((p) => (
+              <div key={p.name} className="px-4 py-2.5">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[13px] font-semibold text-emerald-700">
+                      {p.name}
+                    </span>
+                    <span className="text-[10px] text-slate-500">
+                      {p.proTeam}
+                    </span>
+                  </div>
+                  <span className="text-[14px] font-bold tabular-nums text-emerald-600">
+                    {p.startCount} starts
+                  </span>
+                </div>
+                <div className="mt-1 flex flex-wrap gap-1.5">
+                  {p.starts.map((s, i) => (
+                    <span
+                      key={i}
+                      className="rounded px-2 py-0.5 text-[10px] bg-orange-50 border border-orange-200 text-orange-700"
+                    >
+                      <span className="font-semibold">{fmtDate(s.date)}</span>{" "}
+                      <span className="text-orange-600">{s.opponent}</span>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* FA double starters: grab today */}
+      <div className="rounded-xl border border-emerald-300 bg-surface overflow-hidden">
+        <div className="border-b border-emerald-300 px-4 py-2.5 flex items-center justify-between">
+          <div>
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-emerald-600">
+              FA Double Starters
+            </span>
+            <span className="ml-2 text-[10px] text-slate-500">
+              Grab today before opponents claim them
+            </span>
+          </div>
+          <span className="text-[14px] font-bold tabular-nums text-emerald-600">
+            {faDoubleStarters.length}
+          </span>
+        </div>
+        {faDoubleStarters.length > 0 ? (
+          <div className="divide-y divide-border">
+            {faDoubleStarters.map((fa) => (
+              <div key={fa.name} className="px-4 py-2.5">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[13px] font-semibold text-emerald-700">
+                      {fa.name}
+                    </span>
+                    <span className="text-[10px] text-slate-500">
+                      {fa.team}
+                    </span>
+                  </div>
+                  <span className="text-[14px] font-bold tabular-nums text-emerald-600">
+                    {fa.starts.length} starts
+                  </span>
+                </div>
+                <div className="mt-1 flex flex-wrap gap-1.5">
+                  {fa.starts.map((s, i) => (
+                    <span
+                      key={i}
+                      className="rounded px-2 py-0.5 text-[10px] bg-emerald-50 border border-emerald-200 text-emerald-700"
+                    >
+                      <span className="font-semibold">{fmtDate(s.date)}</span>{" "}
+                      <span className="text-emerald-600">{s.opponent}</span>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="px-4 py-6 text-center text-[12px] text-slate-500">
+            {!probables
+              ? "Probable pitchers not yet available for next week."
+              : "No unrostered double starters found."}
+          </div>
+        )}
+      </div>
+
+      {!probables && (
+        <div className="mt-3 text-[11px] text-slate-400 text-center">
+          Probable pitchers are typically announced 1 to 5 days in advance.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/gm/notes/page.tsx
+++ b/web/src/app/gm/notes/page.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface Note {
+  id: string;
+  section: "trade" | "strategy" | "watchlist";
+  text: string;
+  tags: string[];
+  createdAt: string;
+}
+
+const STORAGE_KEY = "gm-league-notes";
+const SECTION_LABELS: Record<Note["section"], string> = {
+  trade: "Trade Intel",
+  strategy: "Strategy Notes",
+  watchlist: "Player Watch List",
+};
+
+function loadNotes(): Note[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveNotes(notes: Note[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(notes));
+}
+
+function fmtTimestamp(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export default function NotesPage() {
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [newText, setNewText] = useState("");
+  const [newTags, setNewTags] = useState("");
+  const [newSection, setNewSection] = useState<Note["section"]>("strategy");
+  const [filterTag, setFilterTag] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  useEffect(() => {
+    setNotes(loadNotes());
+  }, []);
+
+  const persist = useCallback((updated: Note[]) => {
+    setNotes(updated);
+    saveNotes(updated);
+  }, []);
+
+  const addNote = () => {
+    if (!newText.trim()) return;
+    const tags = newTags
+      .split(",")
+      .map((t) => t.trim().toLowerCase())
+      .filter(Boolean);
+    const note: Note = {
+      id: crypto.randomUUID(),
+      section: newSection,
+      text: newText.trim(),
+      tags,
+      createdAt: new Date().toISOString(),
+    };
+    persist([note, ...notes]);
+    setNewText("");
+    setNewTags("");
+  };
+
+  const deleteNote = (id: string) => {
+    persist(notes.filter((n) => n.id !== id));
+  };
+
+  const allTags = [...new Set(notes.flatMap((n) => n.tags))].sort();
+
+  const filtered = notes.filter((n) => {
+    if (filterTag && !n.tags.includes(filterTag)) return false;
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase();
+      return (
+        n.text.toLowerCase().includes(q) ||
+        n.tags.some((t) => t.includes(q))
+      );
+    }
+    return true;
+  });
+
+  const groupedBySection = (section: Note["section"]) =>
+    filtered.filter((n) => n.section === section);
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-6">
+      <div className="mb-5">
+        <h1 className="text-lg font-bold text-gray-900">League Notes</h1>
+        <span className="text-[12px] text-slate-500">
+          Trade intel, strategy notes, and player watch list
+        </span>
+      </div>
+
+      {/* Add Note */}
+      <div className="mb-6 rounded-xl border border-border bg-surface p-4">
+        <div className="flex gap-3 mb-3">
+          {(Object.entries(SECTION_LABELS) as [Note["section"], string][]).map(
+            ([key, label]) => (
+              <button
+                key={key}
+                onClick={() => setNewSection(key)}
+                className={`rounded px-3 py-1 text-[11px] font-bold transition-colors ${
+                  newSection === key
+                    ? "bg-orange-600/15 text-orange-600"
+                    : "text-slate-500 hover:text-slate-700"
+                }`}
+              >
+                {label}
+              </button>
+            )
+          )}
+        </div>
+        <textarea
+          value={newText}
+          onChange={(e) => setNewText(e.target.value)}
+          placeholder="Write a note..."
+          rows={2}
+          className="w-full rounded border border-border bg-background px-3 py-2 text-[13px] text-slate-700 outline-none placeholder:text-slate-400 resize-none"
+        />
+        <div className="mt-2 flex items-center gap-3">
+          <input
+            type="text"
+            value={newTags}
+            onChange={(e) => setNewTags(e.target.value)}
+            placeholder="Tags (comma separated)"
+            className="flex-1 rounded border border-border bg-background px-3 py-1.5 text-[12px] text-slate-700 outline-none placeholder:text-slate-400"
+          />
+          <button
+            onClick={addNote}
+            disabled={!newText.trim()}
+            className="rounded bg-orange-600 px-4 py-1.5 text-[12px] font-bold text-white transition-colors hover:bg-orange-700 disabled:opacity-40"
+          >
+            Add
+          </button>
+        </div>
+      </div>
+
+      {/* Search and Filter */}
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Search notes..."
+          className="rounded border border-border bg-background px-3 py-1.5 text-[12px] text-slate-700 outline-none placeholder:text-slate-400 w-48"
+        />
+        {allTags.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            <button
+              onClick={() => setFilterTag(null)}
+              className={`rounded px-2 py-0.5 text-[10px] font-bold transition-colors ${
+                filterTag === null
+                  ? "bg-orange-100 text-orange-700"
+                  : "bg-slate-100 text-slate-500 hover:text-slate-700"
+              }`}
+            >
+              All
+            </button>
+            {allTags.map((tag) => (
+              <button
+                key={tag}
+                onClick={() => setFilterTag(filterTag === tag ? null : tag)}
+                className={`rounded px-2 py-0.5 text-[10px] font-bold transition-colors ${
+                  filterTag === tag
+                    ? "bg-orange-100 text-orange-700"
+                    : "bg-slate-100 text-slate-500 hover:text-slate-700"
+                }`}
+              >
+                {tag}
+              </button>
+            ))}
+          </div>
+        )}
+        <span className="text-[10px] text-slate-400 ml-auto">
+          {filtered.length} note{filtered.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      {/* Notes by Section */}
+      {(Object.entries(SECTION_LABELS) as [Note["section"], string][]).map(
+        ([section, label]) => {
+          const sectionNotes = groupedBySection(section);
+          if (sectionNotes.length === 0 && filtered.length > 0) return null;
+          return (
+            <div
+              key={section}
+              className="mb-4 rounded-xl border border-border bg-surface overflow-hidden"
+            >
+              <div className="border-b border-border px-4 py-2.5 flex items-center justify-between">
+                <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-600">
+                  {label}
+                </span>
+                <span className="text-[10px] text-slate-400">
+                  {sectionNotes.length}
+                </span>
+              </div>
+              {sectionNotes.length > 0 ? (
+                <div className="divide-y divide-border">
+                  {sectionNotes.map((note) => (
+                    <div
+                      key={note.id}
+                      className="px-4 py-3 group"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <p className="text-[13px] text-slate-700 whitespace-pre-wrap flex-1">
+                          {note.text}
+                        </p>
+                        <button
+                          onClick={() => deleteNote(note.id)}
+                          className="shrink-0 text-[10px] text-slate-300 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
+                        >
+                          delete
+                        </button>
+                      </div>
+                      <div className="mt-1.5 flex items-center gap-2">
+                        <span className="text-[10px] text-slate-400">
+                          {fmtTimestamp(note.createdAt)}
+                        </span>
+                        {note.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="rounded bg-slate-100 px-1.5 py-0.5 text-[9px] font-bold text-slate-500"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="px-4 py-6 text-center text-[12px] text-slate-400">
+                  No notes yet
+                </div>
+              )}
+            </div>
+          );
+        }
+      )}
+
+      {notes.length === 0 && (
+        <div className="text-center py-12 text-[13px] text-slate-400">
+          No notes yet. Add your first note above.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/gm/pace/page.tsx
+++ b/web/src/app/gm/pace/page.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { EspnAuthRequired } from "@/components/EspnAuthRequired";
+import {
+  CATEGORY_WEIGHTS,
+  categoryTierClass,
+  LOWER_IS_BETTER,
+  isPunt,
+  ALL_CATS_BY_WEIGHT,
+} from "@/lib/category-weights";
+
+interface CategoryRanking {
+  cat: string;
+  weight: number;
+  rank: number;
+  value: number;
+  leaderValue: number;
+  gap: number;
+  tier: "STRONG" | "MIDDLE" | "WEAK";
+  isPunt: boolean;
+}
+
+interface MarginToFlip {
+  cat: string;
+  weight: number;
+  currentRank: number;
+  targetRank: number;
+  myValue: number;
+  targetValue: number;
+  gap: number;
+  direction: "increase" | "decrease";
+}
+
+interface DiagnosisData {
+  teamName: string;
+  record: string;
+  categoryRankings: CategoryRanking[];
+  marginToFlip: MarginToFlip[];
+}
+
+function fmtStat(cat: string, val: number): string {
+  if (!Number.isFinite(val)) return "-";
+  if (cat === "AVG") return val.toFixed(3);
+  if (cat === "ERA" || cat === "WHIP") return val.toFixed(2);
+  return String(Math.round(val));
+}
+
+export default function PacePage() {
+  const [diagnosis, setDiagnosis] = useState<DiagnosisData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/analysis/roster-diagnosis")
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.error) setError(d.error);
+        else setDiagnosis(d);
+      })
+      .catch(() => setError("FETCH_FAILED"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  // Season progress estimate (~26 weeks, started late March)
+  const seasonProgress = useMemo(() => {
+    const seasonStart = new Date("2026-03-25");
+    const seasonEnd = new Date("2026-09-28");
+    const now = new Date();
+    const totalDays = (seasonEnd.getTime() - seasonStart.getTime()) / 86400000;
+    const elapsedDays = Math.max(1, (now.getTime() - seasonStart.getTime()) / 86400000);
+    const pct = Math.min(1, Math.max(0.01, elapsedDays / totalDays));
+    const weeksElapsed = Math.max(1, Math.round(elapsedDays / 7));
+    const weeksTotal = Math.round(totalDays / 7);
+    return { pct, weeksElapsed, weeksTotal, daysRemaining: Math.max(0, Math.round(totalDays - elapsedDays)) };
+  }, []);
+
+  // Pace projections
+  const paceData = useMemo(() => {
+    if (!diagnosis) return [];
+    const { pct } = seasonProgress;
+
+    return diagnosis.categoryRankings.map((cr) => {
+      const isRate = cr.cat === "AVG" || cr.cat === "ERA" || cr.cat === "WHIP";
+      const projectedValue = isRate ? cr.value : cr.value / pct;
+      const leaderProjected = isRate
+        ? cr.leaderValue
+        : cr.leaderValue / pct;
+
+      // Find margin to flip entry
+      const flip = diagnosis.marginToFlip.find((m) => m.cat === cr.cat);
+
+      // Determine per-week needed to reach target rank
+      let perWeekNeeded: number | null = null;
+      if (flip && seasonProgress.weeksElapsed > 0) {
+        const weeksLeft = seasonProgress.weeksTotal - seasonProgress.weeksElapsed;
+        if (weeksLeft > 0 && !isRate) {
+          perWeekNeeded = flip.gap / weeksLeft;
+        }
+      }
+
+      return {
+        ...cr,
+        projectedValue,
+        leaderProjected,
+        flip,
+        perWeekNeeded,
+        isRate,
+      };
+    });
+  }, [diagnosis, seasonProgress]);
+
+  // Group categories
+  const fixable = paceData.filter(
+    (c) => c.flip && !c.isPunt && (c.tier === "MIDDLE" || c.tier === "WEAK")
+  );
+  const comfortable = paceData.filter(
+    (c) => c.tier === "STRONG" && !c.isPunt
+  );
+  const puntCats = paceData.filter((c) => c.isPunt);
+
+  if (loading)
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <div className="flex items-center gap-3 text-slate-500">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-orange-500 border-t-transparent" />
+          Loading pace data...
+        </div>
+      </div>
+    );
+  if (error === "ESPN_CREDS_MISSING" || error === "MY_ESPN_TEAM_ID_MISSING")
+    return (
+      <div className="flex min-h-[70vh] items-center justify-center px-4">
+        <EspnAuthRequired />
+      </div>
+    );
+  if (error || !diagnosis)
+    return (
+      <div className="flex h-64 flex-col items-center justify-center gap-2">
+        <div className="text-red-600">Failed to load</div>
+        <div className="text-[12px] text-slate-500">{error}</div>
+      </div>
+    );
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-6">
+      <div className="mb-5 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-lg font-bold text-gray-900">Category Pace Tracker</h1>
+          <span className="text-[12px] text-slate-500">
+            {diagnosis.teamName} · {diagnosis.record}
+          </span>
+        </div>
+        <div className="text-right">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
+            Season Progress
+          </div>
+          <div className="text-[14px] font-bold tabular-nums text-slate-700">
+            Week {seasonProgress.weeksElapsed}/{seasonProgress.weeksTotal}
+          </div>
+          <div className="text-[10px] text-slate-400">
+            {seasonProgress.daysRemaining}d remaining (
+            {Math.round(seasonProgress.pct * 100)}%)
+          </div>
+        </div>
+      </div>
+
+      {/* Full category table */}
+      <div className="mb-6 rounded-xl border border-border bg-surface overflow-hidden">
+        <div className="border-b border-border px-4 py-2.5">
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-600">
+            All Categories
+          </span>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-[11px]">
+            <thead>
+              <tr className="border-b border-border bg-slate-50 text-left text-[9px] font-semibold uppercase tracking-wider text-slate-500">
+                <th className="px-3 py-2">Cat</th>
+                <th className="px-3 py-2 text-right">Weight</th>
+                <th className="px-3 py-2 text-center">Rank</th>
+                <th className="px-3 py-2 text-right">Current</th>
+                <th className="px-3 py-2 text-right">Projected</th>
+                <th className="px-3 py-2 text-right">Leader Proj</th>
+                <th className="px-3 py-2 text-center">Flip To</th>
+                <th className="px-3 py-2 text-right">Gap</th>
+                <th className="px-3 py-2 text-right">Per Week</th>
+              </tr>
+            </thead>
+            <tbody>
+              {paceData.map((c) => (
+                <tr
+                  key={c.cat}
+                  className={`border-b border-border ${c.isPunt ? "opacity-40" : ""}`}
+                >
+                  <td className={`px-3 py-1.5 font-medium ${categoryTierClass(c.cat)}`}>
+                    {c.cat}
+                  </td>
+                  <td className="px-3 py-1.5 text-right tabular-nums text-slate-500">
+                    {c.weight.toFixed(3)}
+                  </td>
+                  <td className="px-3 py-1.5 text-center">
+                    <span
+                      className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-bold ${
+                        c.tier === "STRONG"
+                          ? "text-emerald-700 bg-emerald-50"
+                          : c.tier === "WEAK"
+                            ? "text-red-700 bg-red-50"
+                            : "text-amber-700 bg-amber-50"
+                      }`}
+                    >
+                      #{c.rank}
+                    </span>
+                  </td>
+                  <td className="px-3 py-1.5 text-right tabular-nums font-mono text-slate-700">
+                    {fmtStat(c.cat, c.value)}
+                  </td>
+                  <td className="px-3 py-1.5 text-right tabular-nums font-mono text-slate-500">
+                    {fmtStat(c.cat, c.projectedValue)}
+                  </td>
+                  <td className="px-3 py-1.5 text-right tabular-nums font-mono text-slate-400">
+                    {fmtStat(c.cat, c.leaderProjected)}
+                  </td>
+                  <td className="px-3 py-1.5 text-center">
+                    {c.flip ? (
+                      <span className="font-bold text-emerald-600">
+                        #{c.flip.targetRank}
+                      </span>
+                    ) : (
+                      <span className="text-slate-300">-</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-1.5 text-right tabular-nums font-mono text-amber-600">
+                    {c.flip ? fmtStat(c.cat, c.flip.gap) : "-"}
+                  </td>
+                  <td className="px-3 py-1.5 text-right tabular-nums font-mono text-slate-500">
+                    {c.perWeekNeeded !== null
+                      ? fmtStat(c.cat, c.perWeekNeeded)
+                      : c.flip && c.isRate
+                        ? "rate"
+                        : "-"}
+                    {c.perWeekNeeded !== null && (
+                      <span className="text-[9px] text-slate-400">/wk</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Three groups */}
+      <div className="grid gap-4 lg:grid-cols-3">
+        {/* Fixable */}
+        <div className="rounded-xl border border-amber-300 bg-surface overflow-hidden">
+          <div className="border-b border-amber-300 px-4 py-2.5">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-amber-600">
+              Fixable
+            </span>
+            <span className="ml-2 text-[10px] text-slate-400">
+              Close to flipping
+            </span>
+          </div>
+          <div className="divide-y divide-border">
+            {fixable.length > 0 ? (
+              fixable.map((c) => (
+                <div key={c.cat} className="px-4 py-2.5">
+                  <div className="flex items-center justify-between">
+                    <span className={`text-[13px] font-bold ${categoryTierClass(c.cat)}`}>
+                      {c.cat}
+                    </span>
+                    <span className="text-[11px] font-mono tabular-nums text-slate-600">
+                      #{c.rank}
+                    </span>
+                  </div>
+                  {c.flip && (
+                    <div className="mt-1 text-[10px] text-amber-600">
+                      Gap of {fmtStat(c.cat, c.flip.gap)} to reach #{c.flip.targetRank}
+                    </div>
+                  )}
+                </div>
+              ))
+            ) : (
+              <div className="px-4 py-4 text-center text-[12px] text-slate-400">
+                No fixable categories
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Comfortable */}
+        <div className="rounded-xl border border-emerald-300 bg-surface overflow-hidden">
+          <div className="border-b border-emerald-300 px-4 py-2.5">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-emerald-600">
+              Comfortable
+            </span>
+            <span className="ml-2 text-[10px] text-slate-400">
+              Safe margin
+            </span>
+          </div>
+          <div className="divide-y divide-border">
+            {comfortable.length > 0 ? (
+              comfortable.map((c) => (
+                <div key={c.cat} className="px-4 py-2.5">
+                  <div className="flex items-center justify-between">
+                    <span className={`text-[13px] font-bold ${categoryTierClass(c.cat)}`}>
+                      {c.cat}
+                    </span>
+                    <span className="text-[11px] font-mono tabular-nums text-emerald-600">
+                      #{c.rank}
+                    </span>
+                  </div>
+                </div>
+              ))
+            ) : (
+              <div className="px-4 py-4 text-center text-[12px] text-slate-400">
+                No strong categories yet
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Punt */}
+        <div className="rounded-xl border border-slate-200 bg-surface overflow-hidden opacity-60">
+          <div className="border-b border-slate-200 px-4 py-2.5">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
+              Punt
+            </span>
+          </div>
+          <div className="divide-y divide-border">
+            {puntCats.map((c) => (
+              <div key={c.cat} className="px-4 py-2.5">
+                <div className="flex items-center justify-between">
+                  <span className="text-[13px] text-slate-400">{c.cat}</span>
+                  <span className="text-[11px] font-mono tabular-nums text-slate-400">
+                    #{c.rank}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/gm/quick/page.tsx
+++ b/web/src/app/gm/quick/page.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { EspnAuthRequired } from "@/components/EspnAuthRequired";
+import {
+  CATEGORY_WEIGHTS,
+  isPunt,
+  LOWER_IS_BETTER,
+} from "@/lib/category-weights";
+
+interface MatchupCat {
+  cat: string;
+  myValue: number | null;
+  oppValue: number | null;
+  result: "WIN" | "LOSS" | "TIE" | "PENDING";
+}
+
+interface MatchupPlayer {
+  name: string;
+  pos: string;
+  slotLabel: string;
+  slotId: number;
+  injuryStatus: string;
+  proTeam: string;
+  stats: Record<string, number>;
+}
+
+interface MatchupData {
+  matchupEndDate: string | null;
+  myTeamName: string;
+  oppTeamName: string;
+  categories: MatchupCat[];
+  myRoster: MatchupPlayer[];
+}
+
+interface CategoryRanking {
+  cat: string;
+  tier: "STRONG" | "MIDDLE" | "WEAK";
+  isPunt: boolean;
+  rank: number;
+  weight: number;
+}
+
+interface ActionItem {
+  priority: "HIGH" | "MEDIUM" | "LOW";
+  type: string;
+  message: string;
+}
+
+interface DiagnosisData {
+  actionItems: ActionItem[];
+  categoryRankings: CategoryRanking[];
+}
+
+interface ProbableStart {
+  date: string;
+  pitcherName: string;
+  opponent: string;
+}
+
+interface ProbablePitchersData {
+  allStarts: ProbableStart[];
+}
+
+interface TeamSchedule {
+  todayOpponent: string | null;
+}
+
+const IL_STATUSES = new Set([
+  "SEVEN_DAY_DL",
+  "TEN_DAY_DL",
+  "FIFTEEN_DAY_DL",
+  "SIXTY_DAY_DL",
+  "OUT",
+]);
+const BENCH_SLOT_ID = 16;
+const BATTER_SLOT_IDS = new Set([0, 1, 2, 3, 4, 5, 6, 7, 8, 12]);
+
+export default function QuickViewPage() {
+  const [matchup, setMatchup] = useState<MatchupData | null>(null);
+  const [diagnosis, setDiagnosis] = useState<DiagnosisData | null>(null);
+  const [probables, setProbables] = useState<ProbablePitchersData | null>(null);
+  const [schedule, setSchedule] = useState<Record<string, TeamSchedule>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const today = new Date().toISOString().slice(0, 10);
+    Promise.all([
+      fetch("/api/espn/matchup").then((r) => r.json()),
+      fetch("/api/analysis/roster-diagnosis")
+        .then((r) => r.json())
+        .catch(() => null),
+      fetch(`/api/mlb/probable-pitchers?startDate=${today}&endDate=${today}`)
+        .then((r) => r.json())
+        .catch(() => null),
+      fetch(`/api/mlb/schedule?startDate=${today}&endDate=${today}`)
+        .then((r) => r.json())
+        .catch(() => ({})),
+    ])
+      .then(([mup, diag, pp, sched]) => {
+        if (mup.error) {
+          setError(mup.error);
+          return;
+        }
+        setMatchup(mup);
+        if (diag && !diag.error) setDiagnosis(diag);
+        if (pp && !pp.error) setProbables(pp);
+        if (!sched.error) setSchedule(sched);
+      })
+      .catch(() => setError("FETCH_FAILED"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  // Matchup score
+  const score = useMemo(() => {
+    if (!matchup) return null;
+    const wins = matchup.categories.filter((c) => c.result === "WIN").length;
+    const losses = matchup.categories.filter(
+      (c) => c.result === "LOSS"
+    ).length;
+    const ties = matchup.categories.filter((c) => c.result === "TIE").length;
+    return { wins, losses, ties };
+  }, [matchup]);
+
+  // Top 3 actions
+  const topActions = useMemo(() => {
+    const actions: string[] = [];
+
+    if (matchup) {
+      // Bench batters with games
+      const benchWithGame = matchup.myRoster.filter(
+        (p) =>
+          p.slotId === BENCH_SLOT_ID &&
+          !IL_STATUSES.has(p.injuryStatus) &&
+          !["SP", "RP"].includes(p.pos) &&
+          schedule[p.proTeam]?.todayOpponent
+      );
+      for (const p of benchWithGame.slice(0, 1)) {
+        actions.push(
+          `Start ${p.name} (benched, has game vs ${schedule[p.proTeam]?.todayOpponent})`
+        );
+      }
+    }
+
+    if (diagnosis) {
+      const highActions = diagnosis.actionItems.filter(
+        (a) => a.priority === "HIGH"
+      );
+      for (const a of highActions.slice(0, 2)) {
+        actions.push(a.message);
+      }
+    }
+
+    // SP pitching today
+    if (matchup && probables) {
+      const today = new Date().toISOString().slice(0, 10);
+      const myNames = new Set(matchup.myRoster.map((p) => p.name));
+      const myStarts = probables.allStarts.filter(
+        (s) => s.date === today && myNames.has(s.pitcherName)
+      );
+      if (myStarts.length > 0 && actions.length < 3) {
+        actions.push(
+          `${myStarts.length} SP${myStarts.length > 1 ? "s" : ""} pitching: ${myStarts.map((s) => s.pitcherName).join(", ")}`
+        );
+      }
+    }
+
+    return actions.slice(0, 3);
+  }, [matchup, diagnosis, probables, schedule]);
+
+  // Bench batters who should be starting
+  const benchShouldStart = useMemo(() => {
+    if (!matchup) return [];
+    return matchup.myRoster
+      .filter(
+        (p) =>
+          p.slotId === BENCH_SLOT_ID &&
+          !IL_STATUSES.has(p.injuryStatus) &&
+          !["SP", "RP"].includes(p.pos) &&
+          schedule[p.proTeam]?.todayOpponent
+      )
+      .slice(0, 3);
+  }, [matchup, schedule]);
+
+  // Next SP start
+  const nextSPStart = useMemo(() => {
+    if (!matchup || !probables) return null;
+    const myNames = new Set(matchup.myRoster.map((p) => p.name));
+    const today = new Date().toISOString().slice(0, 10);
+    const upcoming = probables.allStarts
+      .filter((s) => s.date >= today && myNames.has(s.pitcherName))
+      .sort((a, b) => a.date.localeCompare(b.date));
+    return upcoming[0] ?? null;
+  }, [matchup, probables]);
+
+  if (loading)
+    return (
+      <div className="flex h-64 items-center justify-center text-slate-500">
+        <div className="h-4 w-4 animate-spin rounded-full border-2 border-orange-500 border-t-transparent mr-2" />
+        Loading...
+      </div>
+    );
+  if (error === "ESPN_CREDS_MISSING" || error === "MY_ESPN_TEAM_ID_MISSING")
+    return (
+      <div className="flex min-h-[70vh] items-center justify-center px-4">
+        <EspnAuthRequired />
+      </div>
+    );
+  if (error || !matchup)
+    return (
+      <div className="flex h-64 flex-col items-center justify-center gap-2">
+        <div className="text-red-600">Failed to load</div>
+        <div className="text-[12px] text-slate-500">{error}</div>
+      </div>
+    );
+
+  return (
+    <div className="mx-auto max-w-lg px-4 py-4">
+      {/* Matchup score: big, tappable */}
+      {score && (
+        <div className="mb-4 rounded-2xl border border-border bg-surface px-6 py-5 text-center">
+          <div className="text-[11px] font-semibold uppercase tracking-widest text-slate-400 mb-1">
+            vs {matchup.oppTeamName}
+          </div>
+          <div className="flex items-center justify-center gap-4">
+            <div>
+              <div className="text-4xl font-bold tabular-nums text-emerald-600">
+                {score.wins}
+              </div>
+              <div className="text-[10px] text-slate-500">W</div>
+            </div>
+            <div className="text-2xl text-slate-300">-</div>
+            <div>
+              <div className="text-4xl font-bold tabular-nums text-red-600">
+                {score.losses}
+              </div>
+              <div className="text-[10px] text-slate-500">L</div>
+            </div>
+            {score.ties > 0 && (
+              <>
+                <div className="text-2xl text-slate-300">-</div>
+                <div>
+                  <div className="text-4xl font-bold tabular-nums text-orange-600">
+                    {score.ties}
+                  </div>
+                  <div className="text-[10px] text-slate-500">T</div>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Top 3 actions */}
+      {topActions.length > 0 && (
+        <div className="mb-4 rounded-2xl border border-orange-200 bg-orange-50/50 px-4 py-3">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-orange-600 mb-2">
+            Today&apos;s Actions
+          </div>
+          <div className="space-y-2">
+            {topActions.map((action, i) => (
+              <div
+                key={i}
+                className="flex items-start gap-2 text-[13px] text-slate-700"
+              >
+                <span className="shrink-0 mt-0.5 w-5 h-5 rounded-full bg-orange-100 text-orange-600 text-[10px] font-bold flex items-center justify-center">
+                  {i + 1}
+                </span>
+                <span>{action}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Bench alerts */}
+      {benchShouldStart.length > 0 && (
+        <div className="mb-4 rounded-2xl border border-blue-200 bg-blue-50/50 px-4 py-3">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-blue-600 mb-2">
+            Bench Players With Games
+          </div>
+          {benchShouldStart.map((p) => (
+            <div key={p.name} className="py-1.5 text-[13px] text-slate-700">
+              <span className="font-medium">{p.name}</span>
+              <span className="text-slate-500 ml-1">
+                ({p.pos}) vs {schedule[p.proTeam]?.todayOpponent}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Next SP */}
+      {nextSPStart && (
+        <div className="mb-4 rounded-2xl border border-purple-200 bg-purple-50/50 px-4 py-3">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-purple-600 mb-1">
+            Next SP Start
+          </div>
+          <div className="text-[14px] font-medium text-slate-700">
+            {nextSPStart.pitcherName}
+          </div>
+          <div className="text-[12px] text-slate-500">
+            vs {nextSPStart.opponent} on{" "}
+            {new Date(nextSPStart.date + "T12:00:00").toLocaleDateString(
+              "en-US",
+              { weekday: "short", month: "short", day: "numeric" }
+            )}
+          </div>
+        </div>
+      )}
+
+      <div className="text-center text-[10px] text-slate-400 mt-6">
+        Mobile Quick View
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/gm/trade-simulator/page.tsx
+++ b/web/src/app/gm/trade-simulator/page.tsx
@@ -1,0 +1,541 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { EspnAuthRequired } from "@/components/EspnAuthRequired";
+import {
+  isPunt,
+  CATEGORY_WEIGHTS,
+  LOWER_IS_BETTER,
+  BAT_CATS_BY_WEIGHT,
+  PIT_CATS_BY_WEIGHT,
+  categoryTierHeaderClass,
+} from "@/lib/category-weights";
+
+interface RosterPlayer {
+  name: string;
+  pos: string;
+  slotLabel: string;
+  slotId: number;
+  proTeam: string;
+}
+
+interface EspnTeam {
+  id: number;
+  name: string;
+  roster: RosterPlayer[];
+}
+
+interface LiveTeam {
+  teamId: number;
+  teamName: string;
+  ranks: Record<string, number>;
+  stats: Record<string, number>;
+}
+
+interface ZScorePlayer {
+  name: string;
+  pos: string;
+  onTeamId: number;
+  zScores: Record<string, number>;
+  far: number;
+}
+
+const BAT_CATS = ["TB", "HR", "R", "RBI", "H", "SB", "BB", "AVG"];
+const PIT_CATS = ["W", "K", "WHIP", "QS", "ERA", "L", "HD", "SV"];
+const ALL_CATS = [...BAT_CATS, ...PIT_CATS];
+
+function fmtStat(cat: string, val: number): string {
+  if (!Number.isFinite(val)) return "-";
+  if (cat === "AVG") return val.toFixed(3);
+  if (cat === "ERA" || cat === "WHIP") return val.toFixed(2);
+  return String(Math.round(val));
+}
+
+export default function TradeSimulatorPage() {
+  const [teams, setTeams] = useState<EspnTeam[]>([]);
+  const [liveTeams, setLiveTeams] = useState<LiveTeam[]>([]);
+  const [zPlayers, setZPlayers] = useState<ZScorePlayer[]>([]);
+  const [myTeamId, setMyTeamId] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const [giving, setGiving] = useState<string[]>([]);
+  const [getting, setGetting] = useState<string[]>([]);
+  const [searchGive, setSearchGive] = useState("");
+  const [searchGet, setSearchGet] = useState("");
+
+  useEffect(() => {
+    Promise.all([
+      fetch("/api/espn/roster").then((r) => r.json()),
+      fetch("/api/espn/matchup")
+        .then((r) => r.json())
+        .catch(() => ({})),
+      fetch("/api/espn/league-stats?scope=season")
+        .then((r) => r.json())
+        .catch(() => ({ teams: [] })),
+      fetch("/api/analysis/z-scores")
+        .then((r) => r.json())
+        .catch(() => ({ players: [] })),
+    ])
+      .then(([rosterData, matchupData, leagueData, zData]) => {
+        if (rosterData.error) {
+          setError(rosterData.error);
+          return;
+        }
+        setTeams(rosterData);
+        if (matchupData.myTeamId) setMyTeamId(matchupData.myTeamId);
+        if (leagueData.teams) setLiveTeams(leagueData.teams);
+        setZPlayers(zData.players ?? []);
+      })
+      .catch(() => setError("FETCH_FAILED"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const myTeam = useMemo(
+    () =>
+      teams.find((t) => t.id === myTeamId) ?? (teams.length > 0 ? teams[0] : null),
+    [teams, myTeamId]
+  );
+
+  const allRosteredPlayers = useMemo(() => {
+    const players: (RosterPlayer & { teamId: number; teamName: string })[] = [];
+    for (const t of teams) {
+      for (const p of t.roster) {
+        players.push({ ...p, teamId: t.id, teamName: t.name });
+      }
+    }
+    return players;
+  }, [teams]);
+
+  const zByName = useMemo(() => {
+    const m = new Map<string, ZScorePlayer>();
+    zPlayers.forEach((p) => m.set(p.name, p));
+    return m;
+  }, [zPlayers]);
+
+  const myLiveTeam = useMemo(
+    () => liveTeams.find((t) => t.teamId === (myTeamId ?? 0)),
+    [liveTeams, myTeamId]
+  );
+
+  // Current ranks
+  const currentRanks = useMemo(() => {
+    if (!myLiveTeam) return {} as Record<string, number>;
+    return myLiveTeam.ranks;
+  }, [myLiveTeam]);
+
+  // Estimate rank changes from trade
+  const rankProjections = useMemo(() => {
+    if (!myLiveTeam || (giving.length === 0 && getting.length === 0)) return null;
+
+    const numTeams = liveTeams.length || 12;
+    const projections: Record<
+      string,
+      {
+        currentRank: number;
+        projectedRank: number;
+        change: number;
+        improved: boolean;
+        worsened: boolean;
+      }
+    > = {};
+
+    for (const cat of ALL_CATS) {
+      const currentRank = currentRanks[cat] ?? 6;
+
+      // Sum z-score contributions
+      const givingZ = giving.reduce(
+        (sum, name) => sum + (zByName.get(name)?.zScores[cat] ?? 0),
+        0
+      );
+      const gettingZ = getting.reduce(
+        (sum, name) => sum + (zByName.get(name)?.zScores[cat] ?? 0),
+        0
+      );
+      const netZ = gettingZ - givingZ;
+      const lower = LOWER_IS_BETTER.has(cat);
+
+      // Estimate rank change: each 0.5 z-score roughly = 1 rank position
+      const rankDelta = lower ? netZ * 2 : -netZ * 2;
+      const projRank = Math.max(1, Math.min(numTeams, Math.round(currentRank + rankDelta)));
+      const change = currentRank - projRank;
+
+      projections[cat] = {
+        currentRank,
+        projectedRank: projRank,
+        change,
+        improved: change > 0,
+        worsened: change < 0,
+      };
+    }
+
+    return projections;
+  }, [myLiveTeam, giving, getting, currentRanks, zByName, liveTeams.length]);
+
+  // Net category rank change summary
+  const netSummary = useMemo(() => {
+    if (!rankProjections) return null;
+    let totalChange = 0;
+    const improved: string[] = [];
+    const worsened: string[] = [];
+    for (const [cat, proj] of Object.entries(rankProjections)) {
+      if (isPunt(cat)) continue;
+      totalChange += proj.change;
+      if (proj.change > 0) improved.push(`+${proj.change} ${cat}`);
+      if (proj.change < 0) worsened.push(`${proj.change} ${cat}`);
+    }
+    return { totalChange, improved, worsened };
+  }, [rankProjections]);
+
+  // Filter players for dropdowns
+  const giveOptions = useMemo(() => {
+    if (!myTeam) return [];
+    return myTeam.roster
+      .filter((p) => !giving.includes(p.name))
+      .filter(
+        (p) =>
+          !searchGive ||
+          p.name.toLowerCase().includes(searchGive.toLowerCase())
+      );
+  }, [myTeam, giving, searchGive]);
+
+  const getOptions = useMemo(() => {
+    return allRosteredPlayers
+      .filter((p) => p.teamId !== (myTeamId ?? 0))
+      .filter((p) => !getting.includes(p.name))
+      .filter(
+        (p) =>
+          !searchGet ||
+          p.name.toLowerCase().includes(searchGet.toLowerCase())
+      )
+      .slice(0, 30);
+  }, [allRosteredPlayers, myTeamId, getting, searchGet]);
+
+  if (loading)
+    return (
+      <div className="flex h-64 items-center justify-center text-slate-500">
+        Loading trade simulator...
+      </div>
+    );
+  if (error === "ESPN_CREDS_MISSING")
+    return (
+      <div className="flex min-h-[70vh] items-center justify-center px-4">
+        <EspnAuthRequired />
+      </div>
+    );
+  if (error || !myTeam)
+    return (
+      <div className="flex h-64 flex-col items-center justify-center gap-2">
+        <div className="text-red-600">Failed to load</div>
+        <div className="text-[12px] text-slate-500">{error}</div>
+      </div>
+    );
+
+  const hasTrade = giving.length > 0 || getting.length > 0;
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-6">
+      <div className="mb-5">
+        <h1 className="text-lg font-bold text-gray-900">Trade Simulator</h1>
+        <span className="text-[12px] text-slate-500">
+          See before/after category rank projections
+        </span>
+      </div>
+
+      {/* Two-column: I give / I get */}
+      <div className="grid gap-4 lg:grid-cols-2 mb-6">
+        {/* I Give */}
+        <div className="rounded-lg border border-red-300 bg-surface">
+          <div className="border-b border-red-300 px-3 py-2">
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-red-600">
+              I Give
+            </span>
+          </div>
+          {giving.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 px-3 py-2 border-b border-border">
+              {giving.map((name) => {
+                const z = zByName.get(name);
+                return (
+                  <div
+                    key={name}
+                    className="flex items-center gap-1.5 rounded border border-red-200 bg-red-50 px-2 py-1"
+                  >
+                    <span className="text-[12px] font-medium text-slate-700">
+                      {name}
+                    </span>
+                    {z && (
+                      <span className="text-[10px] text-slate-500 font-mono">
+                        FAR {z.far.toFixed(1)}
+                      </span>
+                    )}
+                    <button
+                      onClick={() =>
+                        setGiving(giving.filter((n) => n !== name))
+                      }
+                      className="text-[10px] text-slate-400 hover:text-red-600 font-bold"
+                    >
+                      x
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+          <div className="px-3 py-2">
+            <input
+              type="text"
+              value={searchGive}
+              onChange={(e) => setSearchGive(e.target.value)}
+              placeholder="Search your roster..."
+              className="w-full rounded border border-border bg-background px-2 py-1 text-[12px] text-slate-700 outline-none placeholder:text-slate-400"
+            />
+          </div>
+          <div className="overflow-y-auto max-h-[240px]">
+            {giveOptions.map((p) => (
+              <button
+                key={p.name}
+                onClick={() => {
+                  setGiving([...giving, p.name]);
+                  setSearchGive("");
+                }}
+                className="flex w-full items-center justify-between border-b border-border px-3 py-2 text-left hover:bg-black/[0.03]"
+              >
+                <div>
+                  <div className="text-[12px] font-medium text-slate-700">
+                    {p.name}
+                  </div>
+                  <div className="text-[10px] text-slate-500">
+                    {p.pos} · {p.proTeam}
+                  </div>
+                </div>
+                {zByName.get(p.name) && (
+                  <span className="text-[10px] font-mono text-slate-500">
+                    FAR {zByName.get(p.name)!.far.toFixed(1)}
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* I Get */}
+        <div className="rounded-lg border border-emerald-300 bg-surface">
+          <div className="border-b border-emerald-300 px-3 py-2">
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-emerald-600">
+              I Get
+            </span>
+          </div>
+          {getting.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 px-3 py-2 border-b border-border">
+              {getting.map((name) => {
+                const z = zByName.get(name);
+                const p = allRosteredPlayers.find((pl) => pl.name === name);
+                return (
+                  <div
+                    key={name}
+                    className="flex items-center gap-1.5 rounded border border-emerald-200 bg-emerald-50 px-2 py-1"
+                  >
+                    <span className="text-[12px] font-medium text-slate-700">
+                      {name}
+                    </span>
+                    {p && (
+                      <span className="text-[9px] text-slate-400">
+                        {p.teamName}
+                      </span>
+                    )}
+                    {z && (
+                      <span className="text-[10px] text-slate-500 font-mono">
+                        FAR {z.far.toFixed(1)}
+                      </span>
+                    )}
+                    <button
+                      onClick={() =>
+                        setGetting(getting.filter((n) => n !== name))
+                      }
+                      className="text-[10px] text-slate-400 hover:text-red-600 font-bold"
+                    >
+                      x
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+          <div className="px-3 py-2">
+            <input
+              type="text"
+              value={searchGet}
+              onChange={(e) => setSearchGet(e.target.value)}
+              placeholder="Search all league rosters..."
+              className="w-full rounded border border-border bg-background px-2 py-1 text-[12px] text-slate-700 outline-none placeholder:text-slate-400"
+            />
+          </div>
+          <div className="overflow-y-auto max-h-[240px]">
+            {getOptions.map((p) => (
+              <button
+                key={`${p.name}-${p.teamId}`}
+                onClick={() => {
+                  setGetting([...getting, p.name]);
+                  setSearchGet("");
+                }}
+                className="flex w-full items-center justify-between border-b border-border px-3 py-2 text-left hover:bg-black/[0.03]"
+              >
+                <div>
+                  <div className="text-[12px] font-medium text-slate-700">
+                    {p.name}
+                  </div>
+                  <div className="text-[10px] text-slate-500">
+                    {p.pos} · {p.proTeam} · {p.teamName}
+                  </div>
+                </div>
+                {zByName.get(p.name) && (
+                  <span className="text-[10px] font-mono text-slate-500">
+                    FAR {zByName.get(p.name)!.far.toFixed(1)}
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Trade Impact */}
+      {hasTrade && rankProjections && netSummary && (
+        <div className="rounded-lg border border-border bg-surface">
+          {/* Net summary */}
+          <div className="border-b border-border px-4 py-3 flex items-center justify-between">
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+              Category Rank Impact
+            </span>
+            <span
+              className={`text-[16px] font-bold tabular-nums ${
+                netSummary.totalChange > 0
+                  ? "text-emerald-600"
+                  : netSummary.totalChange < 0
+                    ? "text-red-600"
+                    : "text-slate-500"
+              }`}
+            >
+              Net {netSummary.totalChange > 0 ? "+" : ""}
+              {netSummary.totalChange} ranks
+            </span>
+          </div>
+
+          {/* Category grid */}
+          {[
+            { label: "Batting", cats: BAT_CATS_BY_WEIGHT },
+            { label: "Pitching", cats: PIT_CATS_BY_WEIGHT },
+          ].map(({ label, cats }) => (
+            <div key={label}>
+              <div className="px-4 py-1.5 text-[9px] font-bold uppercase tracking-widest text-slate-400 bg-black/[0.02]">
+                {label}
+              </div>
+              <div className="grid grid-cols-4 sm:grid-cols-8">
+                {cats.map((cat) => {
+                  const proj = rankProjections[cat];
+                  if (!proj) return null;
+                  const puntCat = isPunt(cat);
+                  return (
+                    <div
+                      key={cat}
+                      className={`border-r border-b border-border last:border-r-0 px-2 py-3 text-center ${
+                        proj.improved
+                          ? "bg-emerald-50"
+                          : proj.worsened
+                            ? "bg-red-50"
+                            : ""
+                      }${puntCat ? " opacity-50" : ""}`}
+                    >
+                      <div
+                        className={`text-[10px] ${categoryTierHeaderClass(cat)}`}
+                      >
+                        {cat}
+                      </div>
+                      <div className="mt-1 text-[11px] text-slate-500">
+                        #{proj.currentRank}
+                      </div>
+                      <div className="text-[10px] text-slate-400">to</div>
+                      <div
+                        className={`text-[13px] font-bold tabular-nums ${
+                          proj.improved
+                            ? "text-emerald-600"
+                            : proj.worsened
+                              ? "text-red-600"
+                              : "text-slate-600"
+                        }`}
+                      >
+                        #{proj.projectedRank}
+                      </div>
+                      {proj.change !== 0 && (
+                        <div
+                          className={`text-[10px] font-bold ${
+                            proj.improved
+                              ? "text-emerald-600"
+                              : "text-red-600"
+                          }`}
+                        >
+                          {proj.change > 0 ? "+" : ""}
+                          {proj.change}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+
+          {/* Detailed changes */}
+          {(netSummary.improved.length > 0 ||
+            netSummary.worsened.length > 0) && (
+            <div className="border-t border-border px-4 py-3 flex flex-wrap gap-4">
+              {netSummary.improved.length > 0 && (
+                <div>
+                  <span className="text-[10px] font-semibold text-emerald-600">
+                    Improves:{" "}
+                  </span>
+                  <span className="text-[11px] text-slate-600">
+                    {netSummary.improved.join(", ")}
+                  </span>
+                </div>
+              )}
+              {netSummary.worsened.length > 0 && (
+                <div>
+                  <span className="text-[10px] font-semibold text-red-600">
+                    Worsens:{" "}
+                  </span>
+                  <span className="text-[11px] text-slate-600">
+                    {netSummary.worsened.join(", ")}
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="px-4 py-3 border-t border-border">
+            <button
+              onClick={() => {
+                setGiving([]);
+                setGetting([]);
+              }}
+              className="text-[11px] text-slate-500 hover:text-slate-700"
+            >
+              Clear trade
+            </button>
+          </div>
+        </div>
+      )}
+
+      {!hasTrade && (
+        <div className="rounded-lg border border-border bg-surface px-6 py-12 text-center">
+          <div className="text-[14px] font-medium text-slate-600">
+            Select players above to simulate a trade
+          </div>
+          <div className="mt-1 text-[12px] text-slate-400">
+            See how your category rankings would change
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/gm/waiver-plan/page.tsx
+++ b/web/src/app/gm/waiver-plan/page.tsx
@@ -1,0 +1,421 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { EspnAuthRequired } from "@/components/EspnAuthRequired";
+import { DataFreshness } from "@/components/DataFreshness";
+import {
+  CATEGORY_WEIGHTS,
+  categoryTierClass,
+  isPunt,
+} from "@/lib/category-weights";
+
+interface CategoryRanking {
+  cat: string;
+  weight: number;
+  rank: number;
+  tier: "STRONG" | "MIDDLE" | "WEAK";
+  isPunt: boolean;
+}
+
+interface DiagnosisData {
+  teamName: string;
+  categoryRankings: CategoryRanking[];
+  marginToFlip: {
+    cat: string;
+    weight: number;
+    currentRank: number;
+    targetRank: number;
+    gap: number;
+  }[];
+}
+
+interface ZScorePlayer {
+  name: string;
+  pos: string;
+  proTeam: string;
+  onTeamId: number;
+  zScores: Record<string, number>;
+  zTotal: number;
+  far: number;
+  seasonStats: Record<string, number>;
+}
+
+interface MatchupPlayer {
+  name: string;
+  pos: string;
+  slotId: number;
+}
+
+interface MatchupData {
+  myRoster: MatchupPlayer[];
+}
+
+interface PlannedMove {
+  type: "add" | "drop";
+  playerName: string;
+  reason: string;
+}
+
+function fmtStat(cat: string, val: number): string {
+  if (!Number.isFinite(val)) return "-";
+  if (cat === "AVG") return val.toFixed(3);
+  if (cat === "ERA" || cat === "WHIP") return val.toFixed(2);
+  return String(Math.round(val));
+}
+
+export default function WaiverPlanPage() {
+  const [diagnosis, setDiagnosis] = useState<DiagnosisData | null>(null);
+  const [zPlayers, setZPlayers] = useState<ZScorePlayer[]>([]);
+  const [matchup, setMatchup] = useState<MatchupData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [plannedMoves, setPlannedMoves] = useState<PlannedMove[]>([]);
+
+  const fetchAll = () => {
+    setLoading(true);
+    Promise.all([
+      fetch("/api/analysis/roster-diagnosis").then((r) => r.json()),
+      fetch("/api/analysis/z-scores")
+        .then((r) => r.json())
+        .catch(() => ({ players: [] })),
+      fetch("/api/espn/matchup")
+        .then((r) => r.json())
+        .catch(() => null),
+    ])
+      .then(([diag, zData, mup]) => {
+        if (diag.error) {
+          setError(diag.error);
+          return;
+        }
+        setDiagnosis(diag);
+        setZPlayers(zData.players ?? []);
+        if (mup && !mup.error) setMatchup(mup);
+      })
+      .catch(() => setError("FETCH_FAILED"))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchAll();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Weak categories
+  const weakCats = useMemo(
+    () =>
+      diagnosis?.categoryRankings
+        .filter((c) => c.tier === "WEAK" && !c.isPunt)
+        .sort((a, b) => b.weight - a.weight) ?? [],
+    [diagnosis]
+  );
+
+  // Free agents sorted by weighted category impact
+  const waiverTargets = useMemo(() => {
+    if (!weakCats.length) return [];
+
+    const freeAgents = zPlayers.filter(
+      (p) => p.onTeamId === 0 && p.far > 0
+    );
+
+    // Score each FA by how much they help weak categories
+    type ScoredFA = ZScorePlayer & {
+      impactScore: number;
+      helpsCats: { cat: string; z: number; weight: number }[];
+    };
+
+    const scored: ScoredFA[] = freeAgents.map((fa) => {
+      let impactScore = 0;
+      const helpsCats: { cat: string; z: number; weight: number }[] = [];
+
+      for (const weak of weakCats) {
+        const z = fa.zScores[weak.cat] ?? 0;
+        if (z > 0) {
+          const weightedImpact = z * (CATEGORY_WEIGHTS[weak.cat] ?? 0) * 100;
+          impactScore += weightedImpact;
+          helpsCats.push({ cat: weak.cat, z, weight: weak.weight });
+        }
+      }
+
+      return { ...fa, impactScore, helpsCats };
+    });
+
+    return scored
+      .filter((fa) => fa.impactScore > 0)
+      .sort((a, b) => b.impactScore - a.impactScore)
+      .slice(0, 15);
+  }, [zPlayers, weakCats]);
+
+  // Drop candidates: bench batters or low-FAR players
+  const dropCandidates = useMemo(() => {
+    if (!matchup) return [];
+    const BENCH_SLOT = 16;
+    const benchPlayers = matchup.myRoster.filter(
+      (p) => p.slotId === BENCH_SLOT
+    );
+    const benchNames = new Set(benchPlayers.map((p) => p.name));
+
+    return zPlayers
+      .filter(
+        (p) =>
+          p.onTeamId !== 0 &&
+          matchup.myRoster.some((r) => r.name === p.name)
+      )
+      .filter((p) => p.far < 1.0 || benchNames.has(p.name))
+      .sort((a, b) => a.far - b.far)
+      .slice(0, 5);
+  }, [matchup, zPlayers]);
+
+  const addPlannedMove = (type: "add" | "drop", name: string, reason: string) => {
+    setPlannedMoves((prev) => [
+      ...prev,
+      { type, playerName: name, reason },
+    ]);
+  };
+
+  const removePlannedMove = (index: number) => {
+    setPlannedMoves((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  if (loading)
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <div className="flex items-center gap-3 text-slate-500">
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-orange-500 border-t-transparent" />
+          Loading waiver data...
+        </div>
+      </div>
+    );
+  if (
+    error === "ESPN_CREDS_MISSING" ||
+    error === "MY_ESPN_TEAM_ID_MISSING"
+  )
+    return (
+      <div className="flex min-h-[70vh] items-center justify-center px-4">
+        <EspnAuthRequired />
+      </div>
+    );
+  if (error || !diagnosis)
+    return (
+      <div className="flex h-64 flex-col items-center justify-center gap-2">
+        <div className="text-red-600">Failed to load</div>
+        <div className="text-[12px] text-slate-500">{error}</div>
+      </div>
+    );
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-6">
+      <div className="mb-5 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-lg font-bold text-gray-900">
+            Waiver Priority Planner
+          </h1>
+          <span className="text-[12px] text-slate-500">
+            FA pickups ranked by category impact
+          </span>
+        </div>
+        <DataFreshness onRefresh={fetchAll} loading={loading} />
+      </div>
+
+      {/* Weak categories */}
+      {weakCats.length > 0 && (
+        <div className="mb-6 rounded-xl border border-red-200 bg-red-50/50 px-4 py-3">
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-red-600 mb-2">
+            Your Weak Categories (targets for improvement)
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {weakCats.map((c) => (
+              <span
+                key={c.cat}
+                className="rounded border border-red-200 bg-white px-2.5 py-1 text-[11px]"
+              >
+                <span className="font-bold text-red-700">{c.cat}</span>
+                <span className="ml-1 text-slate-500">#{c.rank}</span>
+                <span className="ml-1 text-[9px] text-slate-400">
+                  w:{c.weight.toFixed(3)}
+                </span>
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Planned Moves */}
+      <div className="mb-6 rounded-xl border border-orange-300 bg-surface overflow-hidden">
+        <div className="border-b border-orange-300 px-4 py-2.5 flex items-center justify-between">
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-orange-600">
+            Planned Moves
+          </span>
+          <span className="text-[10px] text-slate-400">
+            {plannedMoves.length} move{plannedMoves.length !== 1 ? "s" : ""}
+          </span>
+        </div>
+        {plannedMoves.length > 0 ? (
+          <div className="divide-y divide-border">
+            {plannedMoves.map((move, i) => (
+              <div key={i} className="flex items-center gap-3 px-4 py-2.5">
+                <span
+                  className={`shrink-0 rounded px-2 py-0.5 text-[10px] font-bold ${
+                    move.type === "add"
+                      ? "bg-emerald-100 text-emerald-700"
+                      : "bg-red-100 text-red-700"
+                  }`}
+                >
+                  {move.type === "add" ? "ADD" : "DROP"}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <span className="text-[13px] font-medium text-slate-700">
+                    {move.playerName}
+                  </span>
+                  <span className="ml-2 text-[11px] text-slate-500">
+                    {move.reason}
+                  </span>
+                </div>
+                <button
+                  onClick={() => removePlannedMove(i)}
+                  className="text-[10px] text-slate-400 hover:text-red-600"
+                >
+                  remove
+                </button>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="px-4 py-4 text-center text-[12px] text-slate-400">
+            Click + next to players below to plan moves
+          </div>
+        )}
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {/* Waiver Targets */}
+        <div className="rounded-xl border border-emerald-300 bg-surface overflow-hidden">
+          <div className="border-b border-emerald-300 px-4 py-2.5 flex items-center justify-between">
+            <div>
+              <span className="text-[10px] font-semibold uppercase tracking-wider text-emerald-600">
+                Waiver Targets
+              </span>
+              <span className="ml-2 text-[10px] text-slate-500">
+                By weak category impact
+              </span>
+            </div>
+            <span className="text-[10px] text-slate-400">
+              {waiverTargets.length}
+            </span>
+          </div>
+          <div className="divide-y divide-border">
+            {waiverTargets.map((fa) => (
+              <div key={fa.name} className="px-4 py-2.5">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-[13px] font-medium text-slate-700 truncate">
+                      {fa.name}
+                    </span>
+                    <span className="shrink-0 text-[10px] text-slate-500">
+                      {fa.pos}
+                    </span>
+                    <span className="shrink-0 text-[10px] text-slate-400">
+                      {fa.proTeam}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <span className="text-[11px] font-mono font-bold text-emerald-600 tabular-nums">
+                      FAR {fa.far.toFixed(1)}
+                    </span>
+                    <button
+                      onClick={() =>
+                        addPlannedMove(
+                          "add",
+                          fa.name,
+                          `Helps ${fa.helpsCats.map((c) => c.cat).join(", ")}`
+                        )
+                      }
+                      className="rounded border border-emerald-300 bg-emerald-50 px-1.5 py-0.5 text-[10px] font-bold text-emerald-700 hover:bg-emerald-100"
+                    >
+                      +
+                    </button>
+                  </div>
+                </div>
+                <div className="mt-1 flex flex-wrap gap-1.5">
+                  {fa.helpsCats.map((c) => (
+                    <span
+                      key={c.cat}
+                      className={`text-[10px] ${categoryTierClass(c.cat)}`}
+                    >
+                      {c.cat}{" "}
+                      <span className="text-emerald-600">
+                        +{c.z.toFixed(1)}z
+                      </span>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+            {waiverTargets.length === 0 && (
+              <div className="px-4 py-6 text-center text-[12px] text-slate-400">
+                No targeted free agents found
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Drop Candidates */}
+        <div className="rounded-xl border border-red-300 bg-surface overflow-hidden">
+          <div className="border-b border-red-300 px-4 py-2.5 flex items-center justify-between">
+            <div>
+              <span className="text-[10px] font-semibold uppercase tracking-wider text-red-600">
+                Drop Candidates
+              </span>
+              <span className="ml-2 text-[10px] text-slate-500">
+                Low FAR or benched
+              </span>
+            </div>
+            <span className="text-[10px] text-slate-400">
+              {dropCandidates.length}
+            </span>
+          </div>
+          <div className="divide-y divide-border">
+            {dropCandidates.map((p) => (
+              <div key={p.name} className="px-4 py-2.5">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-[13px] font-medium text-slate-700 truncate">
+                      {p.name}
+                    </span>
+                    <span className="shrink-0 text-[10px] text-slate-500">
+                      {p.pos}
+                    </span>
+                    <span className="shrink-0 text-[10px] text-slate-400">
+                      {p.proTeam}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <span className="text-[11px] font-mono font-bold text-red-600 tabular-nums">
+                      FAR {p.far.toFixed(1)}
+                    </span>
+                    <button
+                      onClick={() =>
+                        addPlannedMove(
+                          "drop",
+                          p.name,
+                          `FAR ${p.far.toFixed(1)}`
+                        )
+                      }
+                      className="rounded border border-red-300 bg-red-50 px-1.5 py-0.5 text-[10px] font-bold text-red-700 hover:bg-red-100"
+                    >
+                      drop
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ))}
+            {dropCandidates.length === 0 && (
+              <div className="px-4 py-6 text-center text-[12px] text-slate-400">
+                No obvious drop candidates
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Daily Actions** (`/gm/actions`): single-screen prioritized action list combining lineup, streaming, waiver, and matchup data
- **Trade Simulator** (`/gm/trade-simulator`): two dropdowns (give/get) with before/after category rank projections, color coded
- **Next Week Lookahead** (`/gm/next-week`): opponent strengths/weaknesses, double starters (roster + FA), schedule density
- **Live Matchup Scoreboard**: enhanced `/gm/matchup` with category-by-category scores, win probability, contested/pushable flags
- **Waiver Priority Planner** (`/gm/waiver-plan`): FA targets ranked by weighted weak category impact, drop candidates, planned moves
- **Player Comparison** (`/gm/compare`): side-by-side z-scores, season stats, verdict weighted by your weak categories
- **Category Pace Tracker** (`/gm/pace`): season projections, flip opportunities, per-week targets, fixable/comfortable/punt groups
- **League Notes** (`/gm/notes`): localStorage notes with Trade Intel, Strategy Notes, Player Watch List sections, tags, search
- **Mobile Quick View** (`/gm/quick`): condensed phone-optimized view: matchup score, top 3 actions, bench alerts, next SP
- **Automated Advice Refresh**: updated `/gm-advice` command with weekly refresh cadence instructions

All features follow existing codebase patterns (client-side fetch, ESPN API, z-scores, category weights). Navigation updated with Actions as first item.

## Test plan
- [x] `npx tsc --noEmit` passes clean
- [x] `npx vitest run` passes (190/190 tests)
- [ ] Verify each page loads in browser with ESPN credentials
- [ ] Check mobile quick view on phone-sized viewport
- [ ] Test notes page localStorage persistence across page reloads